### PR TITLE
Taxonomic assignment rework

### DIFF
--- a/bin/accumulation_curve.R
+++ b/bin/accumulation_curve.R
@@ -1,0 +1,49 @@
+#!/usr/bin/env Rscript
+### load only required packages
+process_packages <- c(
+    "Biostrings",
+    "dada2",
+    "dplyr",
+    "ggplot2",
+    "phyloseq",
+    "purrr",
+    "readr",
+    "scales",
+    "stringr",
+    "tibble",
+    "data.table",
+    "tidyr",
+    "vegan",
+    NULL
+)
+invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+
+### check Nextflow environment variables
+nf_vars <- c(
+    "projectDir",
+    "pcr_primers",
+    "ps_file",
+    "loci_params",
+    "min_sample_reads"
+)
+lapply(nf_vars, nf_var_check)
+
+## check and define variables
+ps <- readRDS(ps_file)
+min_sample_reads <- as.numeric(min_sample_reads)
+
+### run R code
+
+## creates accumulation curve plots and saves plot
+gg.acc_curve <- 
+    rareplot(
+        ps, 
+        step=1L, 
+        threshold = min_sample_reads
+    )
+
+pdf(file=paste0("accumulation_curve_",pcr_primers,".pdf"), width = 11, height = 8 , paper="a4r")
+    print(gg.acc_curve)
+try(dev.off(), silent=TRUE)
+
+# stop(" *** stopped manually *** ") ##########################################

--- a/bin/assignment_plot.R
+++ b/bin/assignment_plot.R
@@ -1,9 +1,11 @@
 #!/usr/bin/env Rscript
 ### load only required packages
 process_packages <- c(
+    "Biostrings",
     "dada2",
     "dplyr",
     "ggplot2",
+    "readr",
     "seqateurs",
     "taxreturn",
     "tibble",
@@ -16,7 +18,7 @@ nf_vars <- c(
     "projectDir",
     "fcid",     
     "pcr_primers",   
-    "seqtab",
+    "fasta",
     "blast",  
     "tax",           
     "target_gene",
@@ -26,9 +28,9 @@ nf_vars <- c(
 lapply(nf_vars, nf_var_check)
 
 ## read in files
-seqtab <-   readRDS(seqtab)
-blast <-    readRDS(blast) # blast is the low-stringency blast output from TAX_BLAST
-tax <-      readRDS(tax)
+fasta <-   Biostrings::readDNAStringSet(fasta)
+blast_input <-   readRDS(blast) # blast is the low-stringency blast output from TAX_BLAST
+tax_input <-      readr::read_csv(tax)
 
 ### run R code
 
@@ -36,38 +38,44 @@ tax <-      readRDS(tax)
 if ( !is.null(blast) ){
 
     # convert blast 'resolve_ties="all"' output to 'resolve_ties="first"'
-    blast <- blast %>%
+    blast <- blast_input %>%
         dplyr::group_by(qseqid) %>% 
         dplyr::mutate(row_n = dplyr::row_number()) %>%
         dplyr::top_n(1, row_n) %>% # Break ties by position
         dplyr::select(-row_n) %>%
         dplyr::ungroup()
 
-    # filter tax table
-    tax <- tax %>% 
-        seqateurs::unclassified_to_na(rownames=FALSE) %>%
-        dplyr::mutate(lowest = seqateurs::lowest_classified(.)) # causes warning: ' argument is not an atomic vector; coercing'
-        ### TODO: resolve above warning message
-
+    # add "lowest" (lowest assigned rank) to tax tibble
+    tax <- 
+      tax_input %>%
+        dplyr::mutate(lowest = dplyr::case_when(
+          stringr::str_detect(Kingdom, "__")  ~ "Root",
+          stringr::str_detect(Phylum, "__")  ~ "Kingdom",
+          stringr::str_detect(Class, "__")  ~ "Phylum",
+          stringr::str_detect(Order, "__")  ~ "Class",
+          stringr::str_detect(Family, "__")  ~ "Order",
+          stringr::str_detect(Genus, "__")  ~ "Family",
+          stringr::str_detect(Species, "__")  ~ "Genus",
+          .default = "Species"
+          )
+        )
+        
     # make seqmap 
-    seqmap <- tibble::enframe(dada2::getSequences(seqtab), name = NULL, value="OTU") %>%
-        dplyr::mutate(name = paste0("SV", seq(length(dada2::getSequences(seqtab)))))
-    # get ASV sequences
-    seqs <- taxreturn::char2DNAbin(seqmap$OTU)
-    names(seqs) <- seqmap$name
+    seqmap <- tibble::enframe(fasta %>% as.character(), name = "seq_name", value="sequence") 
+    # get ASV sequences as named vector
+    seqs <- fasta %>% as.character()
 
     # add sequences to blast output and rename columns
     blast <- blast %>% 
-        dplyr::mutate(blastspp = paste0(Genus, " ", Species)) %>%
-        dplyr::select(name = qseqid, acc, blastspp, pident, total_score, max_score, evalue, qcovs) %>%
-        dplyr::left_join(seqmap) %>%
-        dplyr::select(-name)
+        dplyr::mutate(blastspp = Species) %>%
+        dplyr::select(seq_name = qseqid, acc, blastspp, pident, total_score, max_score, evalue, qcovs) %>%
+        dplyr::left_join(., seqmap, by = dplyr::join_by("seq_name")) 
 
     # combine blast output and tax table
     if ( nrow(blast) > 0 & nrow(tax) > 0 ) {
         joint <- blast %>% 
-            dplyr::left_join(tax, by="OTU")
-        
+            dplyr::left_join(tax, by = "seq_name")
+
     } else {
         joint <- NULL
     }
@@ -99,9 +107,9 @@ if ( !is.null(joint) ) {
         geom_histogram(colour="black", binwidth = 1, position = "stack") + 
         labs(
             title = paste0(fcid, "  ", pcr_primers, " Top hit identity distribution"),
-            subtitle = paste0("IDTAXA database:", idtaxa_db, " BLAST database:", ref_fasta),
+            subtitle = paste0("IDTAXA database:", idtaxa_db, "\nBLAST database:", ref_fasta),
             x = "BLAST top hit % identity",
-            y = "Sequence Variants"
+            y = "ASVs"
             ) + 
         scale_x_continuous(breaks=seq(60,100,2)) +
         scale_fill_manual(name = "Taxonomic \nAssignment", values = cols)+
@@ -130,4 +138,3 @@ if ( !is.null(plot) ){
     text(x=.5, y=.5, "No blast hits to reference fasta -- assignment plot not created") 
     try(dev.off(), silent=TRUE)
 }
-

--- a/bin/assignment_plot.R
+++ b/bin/assignment_plot.R
@@ -19,7 +19,7 @@ nf_vars <- c(
     "fcid",     
     "pcr_primers",   
     "fasta",
-    "blast",  
+    "blast_list",  
     "tax",           
     "target_gene",
     "idtaxa_db",  
@@ -29,7 +29,13 @@ lapply(nf_vars, nf_var_check)
 
 ## read in files
 fasta <-   Biostrings::readDNAStringSet(fasta)
-blast_input <-   readRDS(blast) # blast is the low-stringency blast output from TAX_BLAST
+
+blast_input <- 
+    blast_list %>%
+    stringr::str_split_1(., pattern = " ") %>% # split string of filenames into vector
+    lapply(., readRDS) %>% # read in .rds and store as list of tibbles
+    dplyr::bind_rows()
+
 tax_input <-      readr::read_csv(tax)
 
 ### run R code

--- a/bin/filter_seqtab.R
+++ b/bin/filter_seqtab.R
@@ -19,7 +19,6 @@ nf_vars <- c(
     "projectDir",
     "fcid",
     "pcr_primers",
-    "seqtab",
     "asv_min_length",
     "asv_max_length",
     "phmm",
@@ -56,22 +55,9 @@ multithread <- FALSE # multithreading switched off for now
 # set primers vector
 primers <- c(for_primer_seq, rev_primer_seq)
 
-# read seqtab from file 
-if(is.matrix(seqtab) | is.data.frame(seqtab)){
-    if(!quiet){message("Input is a matrix or data frame")}
-} else if (is.character(seqtab) & stringr::str_detect(seqtab, ".rds")){
-    seqtab <- readRDS(seqtab)
-} else {
-    stop("seqtab must be a matrix/data frame or .rds file")
-}
-
 seqtab_tibble <- readr::read_csv(seqtab_tibble)
 
 seqs_fasta <- Biostrings::readDNAStringSet(fasta)
-
-### run R code
-
-reads_starting <- rowSums(seqtab)
 
 ## Load in profile hidden markov model if provided
 if(is.character(phmm) && stringr::str_detect(phmm, ".rds")){
@@ -120,336 +106,129 @@ if (is(phmm_model, "PHMM") && !is.null(primers)){
     }
 }
 
-## Remove chimeras  
-seqtab_nochim <- dada2::removeBimeraDenovo(
-    seqtab, method="consensus", multithread=multithread, verbose=!quiet
-    )
-seqs_rem <- length(colnames(seqtab_nochim))/length(colnames(seqtab))
-abund_rem <- sum(seqtab_nochim)/sum(seqtab)
-message(paste(round(seqs_rem*100,2), "% of initial sequences and ",round(abund_rem*100,2), "% initial abundance remaining after chimera removal"))
-reads_chimerafilt <- rowSums(seqtab_nochim)
 
-## subset ASVs to those of expected size
-if(any(!is.null(c(asv_min_length, asv_max_length)), na.rm = TRUE) & any(reads_chimerafilt > 0)){
-    if(!is.null(asv_min_length) & !is.null(asv_max_length)){
-        seqtab_cut <- seqtab_nochim[,nchar(colnames(seqtab_nochim)) < asv_max_length & nchar(colnames(seqtab_nochim)) > asv_min_length, drop = FALSE]
-    } else if(is.null(asv_min_length) & !is.null(asv_max_length)){
-        seqtab_cut <- seqtab_nochim[,nchar(colnames(seqtab_nochim)) < asv_max_length, drop = FALSE]
-    } else if(!is.null(asv_min_length) & is.null(asv_max_length)){
-        seqtab_cut <- seqtab_nochim[,nchar(colnames(seqtab_nochim)) > asv_min_length, drop = FALSE]
-    }
-    if(!quiet){
-        seqs_rem <- length(colnames(seqtab_cut))/length(colnames(seqtab))
-        abund_rem <- sum(seqtab_cut)/sum(seqtab)
-        message(paste(round(seqs_rem*100,2), "% of initial sequences and ",round(abund_rem*100,2), "% initial abundance remaining after length filtering"))
-    }
-    reads_lengthfilt <- rowSums(seqtab_cut)
-} else {
-    seqtab_cut <- seqtab_nochim
-    reads_lengthfilt <- rep(0,nrow(seqtab)) 
-    names(reads_lengthfilt) <- rownames(seqtab)
-}
-
-## Align ASVs against phmm
-if (is(phmm_model, "PHMM") & any(reads_lengthfilt > 0)){
-    seqs <- Biostrings::DNAStringSet(colnames(seqtab_cut))
-    names(seqs) <- colnames(seqtab_cut)
-    phmm_filt <- taxreturn::map_to_model(
-        seqs, model = phmm_model, min_score = 100, min_length = 100,
-        shave = FALSE, check_frame = check_frame, kmer_threshold = 0.5, k=5, extra = "fill")
-    seqtab_phmm <- seqtab_cut[,colnames(seqtab_cut) %in% names(phmm_filt), drop = FALSE]
-    if(!quiet){
-        seqs_rem <- length(colnames(seqtab_phmm))/length(colnames(seqtab))
-        abund_rem <- sum(seqtab_phmm)/sum(seqtab)
-        message(paste(round(seqs_rem*100,2), "% of initial sequences and ",round(abund_rem*100,2), "% of initial abundance remaining after PHMM filtering"))
-    }
-    reads_phmmfilt <- rowSums(seqtab_phmm)
-} else {
-    seqtab_phmm <- seqtab_cut
-    reads_phmmfilt <- rep(0,nrow(seqtab)) 
-    names(reads_phmmfilt) <- rownames(seqtab)
-}
-
-print(reads_phmmfilt)
-print(check_frame)
-
-# stop(" *** stopped manually *** ") ##########################################
-
-## Filter sequences containing stop codons
-if(check_frame & any(reads_phmmfilt > 0)){
-    seqs <- Biostrings::DNAStringSet(colnames(seqtab_phmm))
-    names(seqs) <- colnames(seqtab_phmm)
-    codon_filt <- taxreturn::codon_filter(seqs, genetic_code = genetic_code) 
-    seqtab_final <- seqtab_phmm[,colnames(seqtab_phmm) %in% names(codon_filt), drop = FALSE]
-    if(!quiet){
-        seqs_rem <- length(colnames(seqtab_final))/length(colnames(seqtab))
-        abund_rem <- sum(seqtab_final)/sum(seqtab)
-        message(paste(round(seqs_rem*100,2), "% of initial sequences and ",round(abund_rem*100,2), "% of initial abundance remaining after checking reading frame"))
-    }
-    reads_framefilt <- rowSums(seqtab_final)
-} else {
-    seqtab_final <- seqtab_phmm
-    reads_framefilt <- rep(0,nrow(seqtab))
-    names(reads_framefilt) <- rownames(seqtab)
-}
-
-# change sequence names to contain primer names (preceded by single underscore), so merging seqtabs across loci with sample sheets works as intended
-seqtab_final_renamed <- seqtab_final %>% 
-    tibble::as_tibble(rownames = "sample_id") %>%
-    dplyr::mutate(sample_id = paste0(sample_id,"_",pcr_primers)) %>%
-    tibble::column_to_rownames("sample_id") %>% 
-    as.matrix()
-
-reads_final <- rowSums(seqtab_final_renamed)
-
-## Output a cleanup summary
-cleanup <- seqtab %>%
-    as.data.frame() %>%
-    tidyr::pivot_longer( tidyselect::everything(),
-                    names_to = "OTU",
-                    values_to = "Abundance") %>%
-    dplyr::group_by(OTU) %>%
-    dplyr::summarise(Abundance = sum(Abundance)) %>%
-    dplyr::mutate(length  = nchar(OTU)) %>%
-    dplyr::mutate(type = dplyr::case_when(
-        !OTU %in% dada2::getSequences(seqtab_nochim) ~ "Chimera",
-        !OTU %in% dada2::getSequences(seqtab_cut) ~ "Incorrect size",
-        !OTU %in% dada2::getSequences(seqtab_phmm) ~ "PHMM",
-        !OTU %in% dada2::getSequences(seqtab_final) ~ "Stop codons",
-        TRUE ~ "Retained"
-    )) %>%
-    dplyr::mutate(concat = str_detect(OTU, "NNNNNNNNNN")) %>%
-    dplyr::mutate(type = case_when(
-        concat ~ paste0("Unmerged-", type),
-        TRUE ~ type
-    )) %>%
-    dplyr::mutate(pcr_primers = pcr_primers) %>%
-    dplyr::select(-concat)
-
-## Output length distribution plots
-
-# colours of columns
-cols <- c(`Chimera` = "#9e0142",
-        `Unmerged-Chimera` = "#d53e4f",
-        `Incorrect size` = "#f46d43",
-        `Unmerged-Incorrect size` = "#fdae61",
-        `PHMM` = "#fee08b",
-        `Unmerged-PHMM` = "#e6f598",
-        `Stop codons` = "#abdda4",
-        `Unmerged-Stop codons` = "#66c2a5",
-        `Retained` = "#3288bd",
-        `Unmerged-Retained` = "#5e4fa2") 
-
-gg.abundance <- 
-    ggplot2::ggplot(cleanup, aes(x=length, y=log10(Abundance), fill=type)) +
-    geom_col() + 
-    # scale_y_continuous(trans = pseudo_log_trans(sigma = 1)) + 
-    scale_x_continuous(limits=c(min(cleanup$length)-10, max(cleanup$length)+10))+
-    theme_bw()+
-    scale_fill_manual(values = cols)+
-    theme(
-        strip.background = element_rect(colour = "black", fill = "lightgray"),
-        strip.text = element_text(size=9, family = ""),
-        axis.text.x =element_text(angle=45, hjust=1, vjust=1),
-        plot.background = element_blank(),
-        text = element_text(size=9, family = ""),
-        axis.text = element_text(size=8, family = ""),
-        legend.position = "right",
-        panel.border = element_rect(colour = "black", fill=NA, size=0.5),
-        panel.grid = element_line(size = rel(0.5)),
-    ) +
-    labs(
-        title=pcr_primers,
-        subtitle = "Abundance of sequences",
-        x = "ASV length",
-        y = "log10 ASV abundance",
-        fill = "ASV type"
-        )
-
-gg.unique <- 
-    ggplot2::ggplot(cleanup, aes(x=length, fill=type))+
-    geom_histogram(binwidth = 1) + 
-    scale_x_continuous(limits=c(min(cleanup$length)-10, max(cleanup$length)+10))+
-    theme_bw()+
-    scale_fill_manual(values = cols)+
-    theme(
-        strip.background = element_rect(colour = "black", fill = "lightgray"),
-        strip.text = element_text(size=9, family = ""),
-        axis.text.x =element_text(angle=45, hjust=1, vjust=1),
-        plot.background = element_blank(),
-        text = element_text(size=9, family = ""),
-        axis.text = element_text(size=8, family = ""),
-        legend.position = "right",
-        panel.border = element_rect(colour = "black", fill=NA, size=0.5),
-        panel.grid = element_line(size = rel(0.5)),
-    ) +
-    labs(
-        title=pcr_primers,
-        subtitle = "Number of unique sequences",
-        x = "ASV length",
-        y = "Number of unique sequences",
-        fill = "ASV type"
-        )
-
-## Create combined plot
-out_plot <- gg.abundance / gg.unique
-
-
-## outputs
-# plot
-ggsave(paste0(fcid,"_",pcr_primers,"_ASV_cleanup_summary.pdf"), out_plot, width = 11, height = 8)
-# summary table
-dplyr::bind_rows(unique(cleanup)) %>%
-    readr::write_csv(paste0(fcid,"_",pcr_primers,"_ASV_cleanup_summary.csv"))
-# filtered seqtab
-saveRDS(seqtab_final_renamed, paste0(fcid,"_",pcr_primers,"_seqtab.cleaned.rds"))
-
-# for read-tracking
-reads_out <- tibble::tibble(
-    sample_id = rownames(seqtab) %>% stringr::str_remove(pattern="_S[0-9]+_R[1-2]_.*$"),
-    filter_chimera = reads_chimerafilt,
-    filter_length = reads_lengthfilt,
-    filter_phmm = reads_phmmfilt,
-    filter_frame = reads_framefilt,
-    filter_seqtab = reads_final
-    ) %>%
-    tidyr::pivot_longer(
-        cols = filter_chimera:filter_seqtab,
-        names_to = "stage",
-        values_to = "pairs"
-        ) %>% 
-    dplyr::mutate(
-        fcid = fcid, 
-        pcr_primers = pcr_primers
-    ) %>%
-    dplyr::select(stage, sample_id, fcid, pcr_primers, pairs)
-
-readr::write_csv(reads_out, paste0("filter_seqtab_",fcid,"_",pcr_primers,"_readsout.csv"))
-
-# stop(" *** stopped manually *** ") ##########################################
-
-#### new code --------------------------------------------
+### run R code
 
 # convert DSS to tibble of name and seq
 seqs_names <- 
-  seqs_fasta %>% 
-  as.character() %>% 
-  tibble::enframe(name = "seq_name", value = "sequence")
+    seqs_fasta %>% 
+    as.character() %>% 
+    tibble::enframe(name = "seq_name", value = "sequence")
 
 # make a dada2-style seqtab from inputs
 seqtab_matrix <- 
-  seqtab_tibble %>%
-  # add seq string
-  dplyr::left_join(., seqs_names, by = "seq_name") %>%
-  # remove seq_name
-  dplyr::select(-seq_name) %>%
-  # pivot longer
-  tidyr::pivot_longer(cols = !sequence, names_to = "sample_id", values_to = "abundance") %>%
-  dplyr::mutate(abundance = as.integer(abundance)) %>%
-  # pivot wider 
-  tidyr::pivot_wider(names_from = sequence, values_from = abundance) %>%
-  # sample_id as rownames
-  tibble::column_to_rownames(var = "sample_id") %>%
-  # convert to matrix
-  as.matrix() 
+    seqtab_tibble %>%
+    # add seq string
+    dplyr::left_join(., seqs_names, by = "seq_name") %>%
+    # remove seq_name
+    dplyr::select(-seq_name) %>%
+    # pivot longer
+    tidyr::pivot_longer(cols = !sequence, names_to = "sample_id", values_to = "abundance") %>%
+    dplyr::mutate(abundance = as.integer(abundance)) %>%
+    # pivot wider 
+    tidyr::pivot_wider(names_from = sequence, values_from = abundance) %>%
+    # sample_id as rownames
+    tibble::column_to_rownames(var = "sample_id") %>%
+    # convert to matrix
+    as.matrix() 
 
 
 ## Remove chimeras  
 seqtab_nochim <- 
-  dada2::removeBimeraDenovo(
-    seqtab_matrix, 
-    method = "consensus", 
-    multithread = multithread, 
-    verbose = !quiet
-  )
+    dada2::removeBimeraDenovo(
+		seqtab_matrix, 
+		method = "consensus", 
+		multithread = multithread, 
+		verbose = !quiet
+    )
 
 # make tibble of name, sequence and whether it passed the chimera filter
 seqs_chimera_filter <- 
-  seqs_names %>%
-  dplyr::mutate(
-    chimera_filter = sequence %in% colnames(seqtab_nochim)
-  )
+	seqs_names %>%
+	dplyr::mutate(
+		chimera_filter = sequence %in% colnames(seqtab_nochim)
+	)
 
 
 ## remove based on length
 # use seqs_names for this as easier
 seqs_length_filter <- 
-  seqs_names %>%
-  dplyr::mutate(
-    length = stringr::str_count(sequence, "\\w"),
-    pass_min = length > asv_min_length,
-    pass_max = length < asv_max_length,
-    length_filter = pass_min & pass_max
-  ) %>%
-  # make tibble of name, sequence, and whether it passed the length filter
-  dplyr::select(-length, -pass_min, -pass_max)
+    seqs_names %>%
+    dplyr::mutate(
+        length = stringr::str_count(sequence, "\\w"),
+        pass_min = length > asv_min_length,
+        pass_max = length < asv_max_length,
+        length_filter = pass_min & pass_max
+    ) %>%
+    # make tibble of name, sequence, and whether it passed the length filter
+    dplyr::select(-length, -pass_min, -pass_max)
 
 ## PHMM filtering
 if (is(phmm_model, "PHMM")){
     # remove sequences that don't align to PHMM
     phmm_filt_seqtab <- 
-      taxreturn::map_to_model(
-        seqs_fasta, 
-        model = phmm_model, 
-        min_score = 100, 
-        min_length = 100,
-        shave = FALSE, 
-        check_frame = check_frame, 
-        kmer_threshold = 0.5, 
-        k = 5, 
-        extra = "fill"
-      )
+        taxreturn::map_to_model(
+            seqs_fasta, 
+            model = phmm_model, 
+            min_score = 100, 
+            min_length = 100,
+            shave = FALSE, 
+            check_frame = check_frame, 
+            kmer_threshold = 0.5, 
+            k = 5, 
+            extra = "fill"
+        )
     
     # make tibble of name, sequence and whether it passed the PHMM filter
     seqs_phmm_filter <- 
-      seqs_names %>%
-      dplyr::mutate(
-        phmm_filter = seq_name %in% names(phmm_filt_seqtab)
-      )
+        seqs_names %>%
+        dplyr::mutate(
+            phmm_filter = seq_name %in% names(phmm_filt_seqtab)
+        )
 
 } else {
     # all seqs pass filter
     seqs_phmm_filter <- 
-      seqs_names %>%
-      dplyr::mutate(
-        phmm_filter = TRUE
-      )
+        seqs_names %>%
+        dplyr::mutate(
+            phmm_filter = TRUE
+        )
 }
 
 ## frame checking
-if(check_frame & any(reads_phmmfilt > 0)){
-  # remove sequences with wrong frame  
-  codon_filt_dss <- 
-      taxreturn::codon_filter(
-        seqs_fasta, 
-        genetic_code = genetic_code
-      ) 
-  
-  # make tibble of name, sequence and whether it passed the PHMM filter
-  seqs_frame_filter <- 
-    seqs_names %>%
-    dplyr::mutate(
-      frame_filter = seq_name %in% names(codon_filt_dss)
-    )
+if(check_frame){
+    # remove sequences with wrong frame  
+    codon_filt_dss <- 
+        taxreturn::codon_filter(
+            seqs_fasta, 
+            genetic_code = genetic_code
+        ) 
     
-} else {
+    # make tibble of name, sequence and whether it passed the PHMM filter
+    seqs_frame_filter <- 
+        seqs_names %>%
+        dplyr::mutate(
+            frame_filter = seq_name %in% names(codon_filt_dss)
+        )
+        
+    } else {
     # all seqs pass filter
     seqs_frame_filter <- 
-      seqs_names %>%
-      dplyr::mutate(
-        frame_filter = TRUE
-      )
+        seqs_names %>%
+        dplyr::mutate(
+            frame_filter = TRUE
+        )
 }
 
 ## combine all the filters together and add to seqtab_tibble
 seqs_names_filters <- 
-  seqs_names %>%
-  dplyr::left_join(., seqs_chimera_filter, by = dplyr::join_by(seq_name, sequence)) %>%
-  dplyr::left_join(., seqs_length_filter, by = dplyr::join_by(seq_name, sequence)) %>%
-  dplyr::left_join(., seqs_phmm_filter, by = dplyr::join_by(seq_name, sequence)) %>%
-  dplyr::left_join(., seqs_frame_filter, by = dplyr::join_by(seq_name, sequence)) %>%
-  # join to seqtab_tibble
-  dplyr::left_join(seqtab_tibble, ., by = dplyr::join_by(seq_name))
+    seqs_names %>%
+    dplyr::left_join(., seqs_chimera_filter, by = dplyr::join_by(seq_name, sequence)) %>%
+    dplyr::left_join(., seqs_length_filter, by = dplyr::join_by(seq_name, sequence)) %>%
+    dplyr::left_join(., seqs_phmm_filter, by = dplyr::join_by(seq_name, sequence)) %>%
+    dplyr::left_join(., seqs_frame_filter, by = dplyr::join_by(seq_name, sequence)) %>%
+    # join to seqtab_tibble
+    dplyr::left_join(seqtab_tibble, ., by = dplyr::join_by(seq_name))
 
 # save seqtab_tibble
 readr::write_csv(seqs_names_filters, paste0(fcid, "_", pcr_primers, "_seqtab_filtered.csv"))
@@ -457,35 +236,35 @@ readr::write_csv(seqs_names_filters, paste0(fcid, "_", pcr_primers, "_seqtab_fil
 # filter info tibble
 
 filter_info <- 
-  seqs_names_filters %>%
-  tidyr::pivot_longer(
-    cols = !c(seq_name, sequence, chimera_filter, length_filter, phmm_filter, frame_filter), 
-    names_to = "sample_id",
-    values_to = "abundance"
-  ) %>%
-  # summarise down to total abundance across all samples (one row per ASV)
-  dplyr::group_by(seq_name) %>%
-  dplyr::mutate(abundance = sum(abundance)) %>%
-  dplyr::ungroup() %>%
-  dplyr::select(-sample_id) %>%
-  dplyr::distinct() %>%
-  # add extra info
-  dplyr::mutate(
-    length = nchar(sequence),
-    pcr_primers = pcr_primers,
-    concat = stringr::str_detect(sequence, rep(x = "N", times = 10) %>% stringr::str_flatten()),
-    dplyr::across(
-      chimera_filter:frame_filter, 
-      ~ dplyr::case_when(
-        . == TRUE ~ "pass", 
-        . == FALSE ~ "fail"
-      )
-    ),
-    dplyr::across(
-      chimera_filter:frame_filter, 
-      ~ forcats::fct_relevel(., "pass", "fail")
+    seqs_names_filters %>%
+    tidyr::pivot_longer(
+        cols = !c(seq_name, sequence, chimera_filter, length_filter, phmm_filter, frame_filter), 
+        names_to = "sample_id",
+        values_to = "abundance"
+    ) %>%
+    # summarise down to total abundance across all samples (one row per ASV)
+    dplyr::group_by(seq_name) %>%
+    dplyr::mutate(abundance = sum(abundance)) %>%
+    dplyr::ungroup() %>%
+    dplyr::select(-sample_id) %>%
+    dplyr::distinct() %>%
+    # add extra info
+    dplyr::mutate(
+        length = nchar(sequence),
+        pcr_primers = pcr_primers,
+        concat = stringr::str_detect(sequence, rep(x = "N", times = 10) %>% stringr::str_flatten()),
+        dplyr::across(
+            chimera_filter:frame_filter, 
+            ~ dplyr::case_when(
+                . == TRUE ~ "pass", 
+                . == FALSE ~ "fail"
+            )
+        ),
+        dplyr::across(
+            chimera_filter:frame_filter, 
+            ~ forcats::fct_relevel(., "pass", "fail")
+        )
     )
-  )
 
 # save filter summary
 readr::write_csv(filter_info, paste0(fcid, "_", pcr_primers, "_ASV_cleanup.csv"))
@@ -496,83 +275,83 @@ readr::write_csv(filter_info, paste0(fcid, "_", pcr_primers, "_ASV_cleanup.csv")
 
 # function to make generic plot
 ab_plot_fun <- 
-  function(
-    filter_column,
-    filter_name,
-    filter_colour,
-    dataset = filter_info
-  ){
-    filter_column <- enquo(filter_column)
-    # summarise filter
-    dataset %>%
-    dplyr::group_by(!!filter_column, length, concat) %>%
-    dplyr::summarise(abundance = sum(abundance)) %>%
-    dplyr::ungroup() %>%
-    # plot
-    ggplot2::ggplot(., aes(x = length, y = abundance, colour = !!filter_column, shape = concat)) +
-    geom_point(size = 3, alpha = 0.7) + 
-    scale_y_continuous(
-      trans = scales::pseudo_log_trans(sigma = 1), 
-      limits = c(0, dataset$abundance %>% sum),
-      breaks = c(0, 10^seq(1,100,1))
-      ) +
-    scale_x_continuous(limits=c(min(dataset$length)-10, max(dataset$length)+10)) +
-    theme_bw() +
-    scale_colour_manual(values = c("pass" = "grey80", "fail" = filter_colour)) +
-    theme(
-        strip.background = element_rect(colour = "black", fill = "lightgray"),
-        strip.text = element_text(size=9, family = ""),
-        axis.text.x =element_text(angle=45, hjust=1, vjust=1),
-        plot.background = element_blank(),
-        text = element_text(size=9, family = ""),
-        axis.text = element_text(size=8, family = ""),
-        legend.position = "right",
-        panel.border = element_rect(colour = "black", fill=NA, size=0.5),
-        panel.grid = element_line(size = rel(0.5)),
-    ) +
-    labs(
-      subtitle = filter_name,
-      x = "ASV length",
-      y = "ASV abundance",
-      fill = filter_name
-    )
-  }
+    function(
+        filter_column,
+        filter_name,
+        filter_colour,
+        dataset = filter_info
+    ){
+        filter_column <- enquo(filter_column)
+        # summarise filter
+        dataset %>%
+            dplyr::group_by(!!filter_column, length, concat) %>%
+            dplyr::summarise(abundance = sum(abundance)) %>%
+            dplyr::ungroup() %>%
+            # plot
+            ggplot2::ggplot(., aes(x = length, y = abundance, colour = !!filter_column, shape = concat)) +
+            geom_point(size = 3, alpha = 0.7) + 
+            scale_y_continuous(
+                trans = scales::pseudo_log_trans(sigma = 1), 
+                limits = c(0, dataset$abundance %>% sum),
+                breaks = c(0, 10^seq(1,100,1))
+            ) +
+            scale_x_continuous(limits=c(min(dataset$length)-10, max(dataset$length)+10)) +
+            theme_bw() +
+            scale_colour_manual(values = c("pass" = "grey80", "fail" = filter_colour)) +
+            theme(
+                strip.background = element_rect(colour = "black", fill = "lightgray"),
+                strip.text = element_text(size=9, family = ""),
+                axis.text.x =element_text(angle=45, hjust=1, vjust=1),
+                plot.background = element_blank(),
+                text = element_text(size=9, family = ""),
+                axis.text = element_text(size=8, family = ""),
+                legend.position = "right",
+                panel.border = element_rect(colour = "black", fill=NA, size=0.5),
+                panel.grid = element_line(size = rel(0.5)),
+            ) +
+            labs(
+                subtitle = filter_name,
+                x = "ASV length",
+                y = "ASV abundance",
+                fill = filter_name
+            )
+    }
 
 # make plots
 gg.chimera.ab <- 
-  ab_plot_fun(
-    chimera_filter,
-    "Chimera filter",
-    "#9e0142"
-  )
+    ab_plot_fun(
+        chimera_filter,
+        "Chimera filter",
+        "#9e0142"
+    )
 
 gg.length.ab <- 
-  ab_plot_fun(
-    length_filter,
-    "Length filter",
-    "#f46d43"
-  )
+    ab_plot_fun(
+        length_filter,
+        "Length filter",
+        "#f46d43"
+    )
     
 gg.phmm.ab <-
-  ab_plot_fun(
-    phmm_filter,
-    "PHMM filter",
-    "#fee08b"
-  )
+    ab_plot_fun(
+        phmm_filter,
+        "PHMM filter",
+        "#fee08b"
+    )
     
 gg.frame.ab <- 
-  ab_plot_fun(
-    frame_filter,
-    "Frame/stop filter",
-    "#abdda4"
-  )  
+    ab_plot_fun(
+        frame_filter,
+        "Frame/stop filter",
+        "#abdda4"
+    )  
 
 # combine abundance plots
 
 gg.abundance <-
-  gg.chimera.ab + gg.length.ab + gg.phmm.ab + gg.frame.ab +
-  patchwork::plot_layout(ncol = 1, guides = "collect") +
-  patchwork::plot_annotation(title = "ASV abundance", subtitle = paste0("Flowcell: ", fcid, "\nPCR primers: ", pcr_primers))
+    gg.chimera.ab + gg.length.ab + gg.phmm.ab + gg.frame.ab +
+    patchwork::plot_layout(ncol = 1, guides = "collect") +
+    patchwork::plot_annotation(title = "ASV abundance", subtitle = paste0("Flowcell: ", fcid, "\nPCR primers: ", pcr_primers))
 
 ggsave(paste0(fcid, "_", pcr_primers,"_asv_abundance.pdf"), gg.abundance, width = 8, height = 12)
 
@@ -581,81 +360,81 @@ ggsave(paste0(fcid, "_", pcr_primers,"_asv_abundance.pdf"), gg.abundance, width 
 
 # function to make generic plot
 n_plot_fun <- 
-  function(
-    filter_column,
-    filter_name,
-    filter_colour,
-    dataset = filter_info
-  ){
-    filter_column <- enquo(filter_column)
-    # summarise filter
-    dataset %>%
-    dplyr::group_by(!!filter_column, length, concat) %>%
-    dplyr::summarise(n = n()) %>%
-    dplyr::ungroup() %>%
-    # plot
-    ggplot2::ggplot(., aes(x = length, y = n, colour = !!filter_column, shape = concat)) +
-    geom_point(size = 3) + 
-    scale_y_continuous(
-      limits = c(0, dataset$seq_name %>% unique() %>% length())
-      ) +
-    scale_x_continuous(limits=c(min(dataset$length)-10, max(dataset$length)+10)) +
-    theme_bw() +
-    scale_colour_manual(values = c("pass" = "grey80", "fail" = filter_colour)) +
-    theme(
-        strip.background = element_rect(colour = "black", fill = "lightgray"),
-        strip.text = element_text(size=9, family = ""),
-        axis.text.x =element_text(angle=45, hjust=1, vjust=1),
-        plot.background = element_blank(),
-        text = element_text(size=9, family = ""),
-        axis.text = element_text(size=8, family = ""),
-        legend.position = "right",
-        panel.border = element_rect(colour = "black", fill=NA, size=0.5),
-        panel.grid = element_line(size = rel(0.5)),
-    ) +
-    labs(
-      subtitle = filter_name,
-      x = "ASV length",
-      y = "ASV count",
-      fill = filter_name
-    )
-  }
+    function(
+        filter_column,
+        filter_name,
+        filter_colour,
+        dataset = filter_info
+    ){
+        filter_column <- enquo(filter_column)
+        # summarise filter
+        dataset %>%
+            dplyr::group_by(!!filter_column, length, concat) %>%
+            dplyr::summarise(n = n()) %>%
+            dplyr::ungroup() %>%
+            # plot
+            ggplot2::ggplot(., aes(x = length, y = n, colour = !!filter_column, shape = concat)) +
+            geom_point(size = 3) + 
+            scale_y_continuous(
+                limits = c(0, dataset$seq_name %>% unique() %>% length())
+            ) +
+            scale_x_continuous(limits=c(min(dataset$length)-10, max(dataset$length)+10)) +
+            theme_bw() +
+            scale_colour_manual(values = c("pass" = "grey80", "fail" = filter_colour)) +
+            theme(
+                strip.background = element_rect(colour = "black", fill = "lightgray"),
+                strip.text = element_text(size=9, family = ""),
+                axis.text.x =element_text(angle=45, hjust=1, vjust=1),
+                plot.background = element_blank(),
+                text = element_text(size=9, family = ""),
+                axis.text = element_text(size=8, family = ""),
+                legend.position = "right",
+                panel.border = element_rect(colour = "black", fill=NA, size=0.5),
+                panel.grid = element_line(size = rel(0.5)),
+            ) +
+            labs(
+                subtitle = filter_name,
+                x = "ASV length",
+                y = "ASV count",
+                fill = filter_name
+            )
+    }
 
 # make plots
 gg.chimera.n <- 
-  n_plot_fun(
-    chimera_filter,
-    "Chimera filter",
-    "#9e0142"
-  )
+    n_plot_fun(
+        chimera_filter,
+        "Chimera filter",
+        "#9e0142"
+    )
 
 gg.length.n <- 
-  n_plot_fun(
-    length_filter,
-    "Length filter",
-    "#f46d43"
-  )
+    n_plot_fun(
+        length_filter,
+        "Length filter",
+        "#f46d43"
+    )
     
 gg.phmm.n <-
-  n_plot_fun(
-    phmm_filter,
-    "PHMM filter",
-    "#fee08b"
-  )
+    n_plot_fun(
+        phmm_filter,
+        "PHMM filter",
+        "#fee08b"
+    )
     
 gg.frame.n <- 
-  n_plot_fun(
-    frame_filter,
-    "Frame/stop filter",
-    "#abdda4"
-  )  
+    n_plot_fun(
+        frame_filter,
+        "Frame/stop filter",
+        "#abdda4"
+    )  
 
 # combine count plots
 
 gg.n_asvs <-
-  gg.chimera.n + gg.length.n + gg.phmm.n + gg.frame.n +
-  patchwork::plot_layout(ncol = 1, guides = "collect") +
-  patchwork::plot_annotation(title = "Unique ASVs", subtitle = paste0("Flowcell: ", fcid, "\nPCR primers: ", pcr_primers))
+    gg.chimera.n + gg.length.n + gg.phmm.n + gg.frame.n +
+    patchwork::plot_layout(ncol = 1, guides = "collect") +
+    patchwork::plot_annotation(title = "Unique ASVs", subtitle = paste0("Flowcell: ", fcid, "\nPCR primers: ", pcr_primers))
 
 ggsave(paste0(fcid, "_", pcr_primers,"_asv_count.pdf"), gg.n_asvs, width = 8, height = 12)
 
@@ -663,36 +442,34 @@ ggsave(paste0(fcid, "_", pcr_primers,"_asv_count.pdf"), gg.n_asvs, width = 8, he
 ## for read-tracking
 
 # how many reads pass through each filter for each sample?
-seqs_names_filters %>% glimpse
-
 reads_out <- 
-  seqs_names_filters %>% 
-  # rename filters to match format required for read tracking
-  dplyr::rename(
-    "filter_chimera" = chimera_filter,
-    "filter_length" = length_filter,
-    "filter_phmm" = phmm_filter,
-    "filter_frame" = frame_filter
-  ) %>%
-  # add "filter_seqtab" which is passed when all filters are passed
-  dplyr::mutate(filter_seqtab = filter_chimera & filter_length & filter_phmm & filter_frame) %>%
-  tidyr::pivot_longer(
-    cols = !c(seq_name, sequence, filter_chimera, filter_length, filter_phmm, filter_frame, filter_seqtab),
-    names_to = "sample_id",
-    values_to = "abundance"
-  ) %>%
-  dplyr::select(-seq_name, -sequence) %>%
-  dplyr::mutate(fcid = fcid, pcr_primers = pcr_primers) %>%
-  tidyr::pivot_longer(
-    cols = tidyselect::starts_with("filter_"), 
-    names_to = "stage",
-    values_to = "pass"
-  ) %>%
-  dplyr::group_by(sample_id, fcid, pcr_primers, stage, pass) %>%
-  dplyr::summarise(pairs = sum(abundance)) %>%
-  dplyr::ungroup() %>%
-  dplyr::filter(pass == TRUE) %>%
-  dplyr::select(-pass) %>%
-  dplyr::select(stage, sample_id, fcid, pcr_primers, pairs)
+    seqs_names_filters %>% 
+    # rename filters to match format required for read tracking
+    dplyr::rename(
+        "filter_chimera" = chimera_filter,
+        "filter_length" = length_filter,
+        "filter_phmm" = phmm_filter,
+        "filter_frame" = frame_filter
+    ) %>%
+    # add "filter_seqtab" which is passed when all filters are passed
+    dplyr::mutate(filter_seqtab = filter_chimera & filter_length & filter_phmm & filter_frame) %>%
+    tidyr::pivot_longer(
+        cols = !c(seq_name, sequence, filter_chimera, filter_length, filter_phmm, filter_frame, filter_seqtab),
+        names_to = "sample_id",
+        values_to = "abundance"
+    ) %>%
+    dplyr::select(-seq_name, -sequence) %>%
+    dplyr::mutate(fcid = fcid, pcr_primers = pcr_primers) %>%
+    tidyr::pivot_longer(
+        cols = tidyselect::starts_with("filter_"), 
+        names_to = "stage",
+        values_to = "pass"
+    ) %>%
+    dplyr::group_by(sample_id, fcid, pcr_primers, stage, pass) %>%
+    dplyr::summarise(pairs = sum(abundance)) %>%
+    dplyr::ungroup() %>%
+    dplyr::filter(pass == TRUE) %>%
+    dplyr::select(-pass) %>%
+    dplyr::select(stage, sample_id, fcid, pcr_primers, pairs)
 
 readr::write_csv(reads_out, paste0("filter_seqtab_",fcid,"_",pcr_primers,"_readsout.csv"))

--- a/bin/filter_seqtab.R
+++ b/bin/filter_seqtab.R
@@ -26,7 +26,9 @@ nf_vars <- c(
     "coding",
     "genetic_code",
     "for_primer_seq",
-    "rev_primer_seq"
+    "rev_primer_seq",
+    "seqtab_tibble",
+    "fasta"
 )
 lapply(nf_vars, nf_var_check)
 
@@ -62,6 +64,10 @@ if(is.matrix(seqtab) | is.data.frame(seqtab)){
 } else {
     stop("seqtab must be a matrix/data frame or .rds file")
 }
+
+seqtab_tibble <- readr::read_csv(seqtab_tibble)
+
+seqs_fasta <- Biostrings::readDNAStringSet(fasta)
 
 ### run R code
 
@@ -322,3 +328,371 @@ readr::write_csv(reads_out, paste0("filter_seqtab_",fcid,"_",pcr_primers,"_reads
 
 # stop(" *** stopped manually *** ") ##########################################
 
+#### new code --------------------------------------------
+
+# convert DSS to tibble of name and seq
+seqs_names <- 
+  seqs_fasta %>% 
+  as.character() %>% 
+  tibble::enframe(name = "seq_name", value = "sequence")
+
+# make a dada2-style seqtab from inputs
+seqtab_matrix <- 
+  seqtab_tibble %>%
+  # add seq string
+  dplyr::left_join(., seqs_names, by = "seq_name") %>%
+  # remove seq_name
+  dplyr::select(-seq_name) %>%
+  # pivot longer
+  tidyr::pivot_longer(cols = !sequence, names_to = "sample_id", values_to = "abundance") %>%
+  dplyr::mutate(abundance = as.integer(abundance)) %>%
+  # pivot wider 
+  tidyr::pivot_wider(names_from = sequence, values_from = abundance) %>%
+  # sample_id as rownames
+  tibble::column_to_rownames(var = "sample_id") %>%
+  # convert to matrix
+  as.matrix() 
+
+
+## Remove chimeras  
+seqtab_nochim <- 
+  dada2::removeBimeraDenovo(
+    seqtab_matrix, 
+    method = "consensus", 
+    multithread = multithread, 
+    verbose = !quiet
+  )
+
+# make tibble of name, sequence and whether it passed the chimera filter
+seqs_chimera_filter <- 
+  seqs_names %>%
+  dplyr::mutate(
+    chimera_filter = sequence %in% colnames(seqtab_nochim)
+  )
+
+
+## remove based on length
+# use seqs_names for this as easier
+seqs_length_filter <- 
+  seqs_names %>%
+  dplyr::mutate(
+    length = stringr::str_count(sequence, "\\w"),
+    pass_min = length > asv_min_length,
+    pass_max = length < asv_max_length,
+    length_filter = pass_min & pass_max
+  ) %>%
+  # make tibble of name, sequence, and whether it passed the length filter
+  dplyr::select(-length, -pass_min, -pass_max)
+
+## PHMM filtering
+if (is(phmm_model, "PHMM")){
+    # remove sequences that don't align to PHMM
+    phmm_filt_seqtab <- 
+      taxreturn::map_to_model(
+        seqs_fasta, 
+        model = phmm_model, 
+        min_score = 100, 
+        min_length = 100,
+        shave = FALSE, 
+        check_frame = check_frame, 
+        kmer_threshold = 0.5, 
+        k = 5, 
+        extra = "fill"
+      )
+    
+    # make tibble of name, sequence and whether it passed the PHMM filter
+    seqs_phmm_filter <- 
+      seqs_names %>%
+      dplyr::mutate(
+        phmm_filter = seq_name %in% names(phmm_filt_seqtab)
+      )
+
+} else {
+    # all seqs pass filter
+    seqs_phmm_filter <- 
+      seqs_names %>%
+      dplyr::mutate(
+        phmm_filter = TRUE
+      )
+}
+
+## frame checking
+if(check_frame & any(reads_phmmfilt > 0)){
+  # remove sequences with wrong frame  
+  codon_filt_dss <- 
+      taxreturn::codon_filter(
+        seqs_fasta, 
+        genetic_code = genetic_code
+      ) 
+  
+  # make tibble of name, sequence and whether it passed the PHMM filter
+  seqs_frame_filter <- 
+    seqs_names %>%
+    dplyr::mutate(
+      frame_filter = seq_name %in% names(codon_filt_dss)
+    )
+    
+} else {
+    # all seqs pass filter
+    seqs_frame_filter <- 
+      seqs_names %>%
+      dplyr::mutate(
+        frame_filter = TRUE
+      )
+}
+
+## combine all the filters together and add to seqtab_tibble
+seqs_names_filters <- 
+  seqs_names %>%
+  dplyr::left_join(., seqs_chimera_filter, by = dplyr::join_by(seq_name, sequence)) %>%
+  dplyr::left_join(., seqs_length_filter, by = dplyr::join_by(seq_name, sequence)) %>%
+  dplyr::left_join(., seqs_phmm_filter, by = dplyr::join_by(seq_name, sequence)) %>%
+  dplyr::left_join(., seqs_frame_filter, by = dplyr::join_by(seq_name, sequence)) %>%
+  # join to seqtab_tibble
+  dplyr::left_join(seqtab_tibble, ., by = dplyr::join_by(seq_name))
+
+# save seqtab_tibble
+readr::write_csv(seqs_names_filters, paste0(fcid, "_", pcr_primers, "_seqtab_filtered.csv"))
+
+# filter info tibble
+
+filter_info <- 
+  seqs_names_filters %>%
+  tidyr::pivot_longer(
+    cols = !c(seq_name, sequence, chimera_filter, length_filter, phmm_filter, frame_filter), 
+    names_to = "sample_id",
+    values_to = "abundance"
+  ) %>%
+  # summarise down to total abundance across all samples (one row per ASV)
+  dplyr::group_by(seq_name) %>%
+  dplyr::mutate(abundance = sum(abundance)) %>%
+  dplyr::ungroup() %>%
+  dplyr::select(-sample_id) %>%
+  dplyr::distinct() %>%
+  # add extra info
+  dplyr::mutate(
+    length = nchar(sequence),
+    pcr_primers = pcr_primers,
+    concat = stringr::str_detect(sequence, rep(x = "N", times = 10) %>% stringr::str_flatten()),
+    dplyr::across(
+      chimera_filter:frame_filter, 
+      ~ dplyr::case_when(
+        . == TRUE ~ "pass", 
+        . == FALSE ~ "fail"
+      )
+    ),
+    dplyr::across(
+      chimera_filter:frame_filter, 
+      ~ forcats::fct_relevel(., "pass", "fail")
+    )
+  )
+
+# save filter summary
+readr::write_csv(filter_info, paste0(fcid, "_", pcr_primers, "_ASV_cleanup.csv"))
+
+## plots
+
+# Output length distribution plots
+
+# function to make generic plot
+ab_plot_fun <- 
+  function(
+    filter_column,
+    filter_name,
+    filter_colour,
+    dataset = filter_info
+  ){
+    filter_column <- enquo(filter_column)
+    # summarise filter
+    dataset %>%
+    dplyr::group_by(!!filter_column, length, concat) %>%
+    dplyr::summarise(abundance = sum(abundance)) %>%
+    dplyr::ungroup() %>%
+    # plot
+    ggplot2::ggplot(., aes(x = length, y = abundance, colour = !!filter_column, shape = concat)) +
+    geom_point(size = 3, alpha = 0.7) + 
+    scale_y_continuous(
+      trans = scales::pseudo_log_trans(sigma = 1), 
+      limits = c(0, dataset$abundance %>% sum),
+      breaks = c(0, 10^seq(1,100,1))
+      ) +
+    scale_x_continuous(limits=c(min(dataset$length)-10, max(dataset$length)+10)) +
+    theme_bw() +
+    scale_colour_manual(values = c("pass" = "grey80", "fail" = filter_colour)) +
+    theme(
+        strip.background = element_rect(colour = "black", fill = "lightgray"),
+        strip.text = element_text(size=9, family = ""),
+        axis.text.x =element_text(angle=45, hjust=1, vjust=1),
+        plot.background = element_blank(),
+        text = element_text(size=9, family = ""),
+        axis.text = element_text(size=8, family = ""),
+        legend.position = "right",
+        panel.border = element_rect(colour = "black", fill=NA, size=0.5),
+        panel.grid = element_line(size = rel(0.5)),
+    ) +
+    labs(
+      subtitle = filter_name,
+      x = "ASV length",
+      y = "ASV abundance",
+      fill = filter_name
+    )
+  }
+
+# make plots
+gg.chimera.ab <- 
+  ab_plot_fun(
+    chimera_filter,
+    "Chimera filter",
+    "#9e0142"
+  )
+
+gg.length.ab <- 
+  ab_plot_fun(
+    length_filter,
+    "Length filter",
+    "#f46d43"
+  )
+    
+gg.phmm.ab <-
+  ab_plot_fun(
+    phmm_filter,
+    "PHMM filter",
+    "#fee08b"
+  )
+    
+gg.frame.ab <- 
+  ab_plot_fun(
+    frame_filter,
+    "Frame/stop filter",
+    "#abdda4"
+  )  
+
+# combine abundance plots
+
+gg.abundance <-
+  gg.chimera.ab + gg.length.ab + gg.phmm.ab + gg.frame.ab +
+  patchwork::plot_layout(ncol = 1, guides = "collect") +
+  patchwork::plot_annotation(title = "ASV abundance", subtitle = paste0("Flowcell: ", fcid, "\nPCR primers: ", pcr_primers))
+
+ggsave(paste0(fcid, "_", pcr_primers,"_asv_abundance.pdf"), gg.abundance, width = 8, height = 12)
+
+
+## ASV count plots
+
+# function to make generic plot
+n_plot_fun <- 
+  function(
+    filter_column,
+    filter_name,
+    filter_colour,
+    dataset = filter_info
+  ){
+    filter_column <- enquo(filter_column)
+    # summarise filter
+    dataset %>%
+    dplyr::group_by(!!filter_column, length, concat) %>%
+    dplyr::summarise(n = n()) %>%
+    dplyr::ungroup() %>%
+    # plot
+    ggplot2::ggplot(., aes(x = length, y = n, colour = !!filter_column, shape = concat)) +
+    geom_point(size = 3) + 
+    scale_y_continuous(
+      limits = c(0, dataset$seq_name %>% unique() %>% length())
+      ) +
+    scale_x_continuous(limits=c(min(dataset$length)-10, max(dataset$length)+10)) +
+    theme_bw() +
+    scale_colour_manual(values = c("pass" = "grey80", "fail" = filter_colour)) +
+    theme(
+        strip.background = element_rect(colour = "black", fill = "lightgray"),
+        strip.text = element_text(size=9, family = ""),
+        axis.text.x =element_text(angle=45, hjust=1, vjust=1),
+        plot.background = element_blank(),
+        text = element_text(size=9, family = ""),
+        axis.text = element_text(size=8, family = ""),
+        legend.position = "right",
+        panel.border = element_rect(colour = "black", fill=NA, size=0.5),
+        panel.grid = element_line(size = rel(0.5)),
+    ) +
+    labs(
+      subtitle = filter_name,
+      x = "ASV length",
+      y = "ASV count",
+      fill = filter_name
+    )
+  }
+
+# make plots
+gg.chimera.n <- 
+  n_plot_fun(
+    chimera_filter,
+    "Chimera filter",
+    "#9e0142"
+  )
+
+gg.length.n <- 
+  n_plot_fun(
+    length_filter,
+    "Length filter",
+    "#f46d43"
+  )
+    
+gg.phmm.n <-
+  n_plot_fun(
+    phmm_filter,
+    "PHMM filter",
+    "#fee08b"
+  )
+    
+gg.frame.n <- 
+  n_plot_fun(
+    frame_filter,
+    "Frame/stop filter",
+    "#abdda4"
+  )  
+
+# combine count plots
+
+gg.n_asvs <-
+  gg.chimera.n + gg.length.n + gg.phmm.n + gg.frame.n +
+  patchwork::plot_layout(ncol = 1, guides = "collect") +
+  patchwork::plot_annotation(title = "Unique ASVs", subtitle = paste0("Flowcell: ", fcid, "\nPCR primers: ", pcr_primers))
+
+ggsave(paste0(fcid, "_", pcr_primers,"_asv_count.pdf"), gg.n_asvs, width = 8, height = 12)
+
+
+## for read-tracking
+
+# how many reads pass through each filter for each sample?
+seqs_names_filters %>% glimpse
+
+reads_out <- 
+  seqs_names_filters %>% 
+  # rename filters to match format required for read tracking
+  dplyr::rename(
+    "filter_chimera" = chimera_filter,
+    "filter_length" = length_filter,
+    "filter_phmm" = phmm_filter,
+    "filter_frame" = frame_filter
+  ) %>%
+  # add "filter_seqtab" which is passed when all filters are passed
+  dplyr::mutate(filter_seqtab = filter_chimera & filter_length & filter_phmm & filter_frame) %>%
+  tidyr::pivot_longer(
+    cols = !c(seq_name, sequence, filter_chimera, filter_length, filter_phmm, filter_frame, filter_seqtab),
+    names_to = "sample_id",
+    values_to = "abundance"
+  ) %>%
+  dplyr::select(-seq_name, -sequence) %>%
+  dplyr::mutate(fcid = fcid, pcr_primers = pcr_primers) %>%
+  tidyr::pivot_longer(
+    cols = tidyselect::starts_with("filter_"), 
+    names_to = "stage",
+    values_to = "pass"
+  ) %>%
+  dplyr::group_by(sample_id, fcid, pcr_primers, stage, pass) %>%
+  dplyr::summarise(pairs = sum(abundance)) %>%
+  dplyr::ungroup() %>%
+  dplyr::filter(pass == TRUE) %>%
+  dplyr::select(-pass) %>%
+  dplyr::select(stage, sample_id, fcid, pcr_primers, pairs)
+
+readr::write_csv(reads_out, paste0("filter_seqtab_",fcid,"_",pcr_primers,"_readsout.csv"))

--- a/bin/functions.R
+++ b/bin/functions.R
@@ -385,3 +385,53 @@ rareplot <- function(ps, step="auto", threshold=0){
   
   return(gg.rare)
 }
+
+#' write fasta
+#'
+#' @param x a list of sequences in DNAbin or AAbin format, or a vector of sequences as concatenated upper-case character strings.
+#' @param file character string giving a valid file path to output the text to. If file = "" (default setting) the text file is written to the console.
+#' @param compress logical indicating whether the output file should be gzipped.
+#' @param quiet Whether progress should be printed to consoe
+#'
+#' @return
+#' @export
+#'
+#' @examples
+write_fasta <- function(x, file = "", compress = FALSE, quiet=FALSE) {
+  if(stringr::str_detect(file, "\\.gz$") & !compress){
+    compress <- TRUE
+    if(!quiet) message(".gz detected in filename, compressing output file")
+  }
+  if (!is.null(dim(x))) {
+    x <- as.list(as.data.frame(t(unclass(x))))
+  }
+  if (inherits(x, "DNAbin")) {
+    tmp <- DNAbin2char(x)
+  } else if (is.list(x)) {
+    if (length(x[[1]] == 1)) {
+      tmp <- unlist(x, use.names = TRUE)
+    }
+    else {
+      tmp <- sapply(x, paste0, collapse = "")
+    }
+  } else {
+    tmp <- x
+  }
+  reslen <- 2 * length(tmp)
+  res <- character(reslen)
+  res[seq(1, reslen, by = 2)] <- paste0(">", names(tmp))
+  res[seq(2, reslen, by = 2)] <- tmp
+  if(!file == ""){
+    f <- if(compress){
+        gzfile(file, "w")
+      } else {
+        file(file, "w")
+    }
+    writeLines(res, f)
+    close(f)
+  } else {
+    writeLines(res)
+  }
+  if(!quiet){message("Wrote ", length(tmp), " sequences to ", file)}
+  invisible(NULL)
+}

--- a/bin/functions.R
+++ b/bin/functions.R
@@ -343,13 +343,13 @@ rareplot <- function(ps, step="auto", threshold=0){
   ps <- ps %>%
     phyloseq::prune_samples(sample_sums(.)>0, .) %>% 
     phyloseq::filter_taxa(function(x) mean(x) > 0, TRUE) #Drop missing taxa from table
-  rare <- otu_table(ps) %>%
+  rare <- phyloseq::otu_table(ps) %>%
     as("matrix") %>%
     vegan::rarecurve(step=step) %>% 
     purrr::set_names(sample_names(ps)) %>%
     purrr::map_dfr(., function(x){
       b <- as.data.frame(x)
-      b <- data.frame(OTU = b[,1], count = rownames(b))
+      b <- data.frame(ASV = b[,1], count = rownames(b))
       b$count <- as.numeric(gsub("N", "",  b$count))
       return(b)
     },.id="sample_id") %>%
@@ -361,11 +361,11 @@ rareplot <- function(ps, step="auto", threshold=0){
   
   gg.rare <- rare %>%
     ggplot2::ggplot() +
-    geom_line(aes(x = count, y = OTU, group=sample_id), alpha=0.3)+
+    geom_line(aes(x = count, y = ASV, group=sample_id), alpha=0.3)+
     geom_point(data = rare %>% 
                  group_by(sample_id) %>% 
                  top_n(1, count),
-               aes(x = count, y = OTU, colour=count > threshold)) +
+               aes(x = count, y = ASV, colour=count > threshold)) +
     scale_x_continuous(label = scales::label_number(scale_cut = append(scales::cut_short_scale(), 1, 1)))+
     scale_colour_manual(values=c("FALSE" = "#F8766D", "TRUE"="#619CFF"))+
     facet_wrap(fcid~., scales="free", ncol=1)+

--- a/bin/functions.R
+++ b/bin/functions.R
@@ -333,57 +333,62 @@ melt_phyloseq <- function(ps) {
 }
 
 rareplot <- function(ps, step="auto", threshold=0){
-  if(step == "auto"){
-    step <- round(max(sample_sums(ps)) / 100)
-  } else if (is.integer(step)){
-    step <- step
-  } else {
-    stop("Step must be an integer or 'auto' ")
-  }
-  ps <- ps %>%
-    phyloseq::prune_samples(sample_sums(.)>0, .) %>% 
-    phyloseq::filter_taxa(function(x) mean(x) > 0, TRUE) #Drop missing taxa from table
-  rare <- phyloseq::otu_table(ps) %>%
-    as("matrix") %>%
-    vegan::rarecurve(step=step) %>% 
-    purrr::set_names(sample_names(ps)) %>%
-    purrr::map_dfr(., function(x){
-      b <- as.data.frame(x)
-      b <- data.frame(ASV = b[,1], count = rownames(b))
-      b$count <- as.numeric(gsub("N", "",  b$count))
-      return(b)
-    },.id="sample_id") %>%
-    left_join(phyloseq::sample_data(ps)%>%
+    if(step == "auto"){
+        step <- round(max(sample_sums(ps)) / 100)
+    } else if (is.integer(step)){
+        step <- step
+    } else {
+        stop("Step must be an integer or 'auto' ")
+    }
+    ps <- ps %>%
+        phyloseq::prune_samples(sample_sums(.)>0, .) %>% 
+        phyloseq::filter_taxa(function(x) mean(x) > 0, TRUE) #Drop missing taxa from table
+    rare <- 
+        phyloseq::otu_table(ps) %>%
+        as("matrix") %>%
+        t() %>%
+        vegan::rarecurve(step=step) %>% 
+        purrr::set_names(sample_names(ps)) %>%
+        purrr::map_dfr(., function(x){
+            b <- as.data.frame(x)
+            b <- data.frame(ASV = b[,1], count = rownames(b))
+            b$count <- as.numeric(gsub("N", "",  b$count))
+            return(b)
+        },.id="sample_id") %>%
+        left_join(
+            phyloseq::sample_data(ps) %>%
                 as("matrix") %>%
                 tibble::as_tibble() %>%
                 dplyr::select(sample_id, fcid) %>%
-                dplyr::distinct())
-  
-  gg.rare <- rare %>%
-    ggplot2::ggplot() +
-    geom_line(aes(x = count, y = ASV, group=sample_id), alpha=0.3)+
-    geom_point(data = rare %>% 
-                 group_by(sample_id) %>% 
-                 top_n(1, count),
-               aes(x = count, y = ASV, colour=count > threshold)) +
-    scale_x_continuous(label = scales::label_number(scale_cut = append(scales::cut_short_scale(), 1, 1)))+
-    scale_colour_manual(values=c("FALSE" = "#F8766D", "TRUE"="#619CFF"))+
-    facet_wrap(fcid~., scales="free", ncol=1)+
-    theme_bw()+
-    theme(
-      strip.background = element_rect(colour = "black", fill = "lightgray"),
-      strip.text = element_text(size=9, family = ""),
-      plot.background = element_blank(),
-      text = element_text(size=9, family = ""),
-      axis.text = element_text(size=8, family = ""),
-      legend.position = "bottom",
-      panel.border = element_rect(colour = "black", fill=NA, size=0.5),
-      panel.grid = element_line(size = rel(0.5)),
-    ) + labs(x = "Sequence reads",
-         y = "Observed ASVs",
-         colour = "Above sample filtering theshold") 
-  
-  return(gg.rare)
+                dplyr::distinct(),
+            by = "sample_id"
+        )
+    
+    gg.rare <- rare %>%
+        ggplot2::ggplot() +
+        geom_line(aes(x = count, y = ASV, group=sample_id), alpha=0.3)+
+        geom_point(data = rare %>% 
+                    group_by(sample_id) %>% 
+                    top_n(1, count),
+                aes(x = count, y = ASV, colour=count > threshold)) +
+        scale_x_continuous(label = scales::label_number(scale_cut = append(scales::cut_short_scale(), 1, 1)))+
+        scale_colour_manual(values=c("FALSE" = "#F8766D", "TRUE"="#619CFF"))+
+        facet_wrap(fcid~., scales="free", ncol=1)+
+        theme_bw()+
+        theme(
+        strip.background = element_rect(colour = "black", fill = "lightgray"),
+        strip.text = element_text(size=9, family = ""),
+        plot.background = element_blank(),
+        text = element_text(size=9, family = ""),
+        axis.text = element_text(size=8, family = ""),
+        legend.position = "bottom",
+        panel.border = element_rect(colour = "black", fill=NA, size=0.5),
+        panel.grid = element_line(size = rel(0.5)),
+        ) + labs(x = "Sequence reads",
+            y = "Observed ASVs",
+            colour = "Above sample filtering theshold") 
+    
+    return(gg.rare)
 }
 
 #' write fasta

--- a/bin/joint_tax.R
+++ b/bin/joint_tax.R
@@ -3,6 +3,7 @@
 process_packages <- c(
     "dplyr",
     "purrr",
+    "readr",
     "stringr",
     "tibble",
     NULL
@@ -17,7 +18,7 @@ nf_vars <- c(
     "target_gene",
     "idtaxa_output",
     "blast_output",
-    "seqtab"
+    "seqtab_tibble"
 )
 lapply(nf_vars, nf_var_check)
 
@@ -27,70 +28,76 @@ target_gene <-          parse_nf_var_repeat(target_gene)
 propagate_tax <-        TRUE
 
 ### run R code      # derived from step_join_tax_blast() in functions.R and tar_target(joint_tax)
-idtaxa_output <-              readRDS(idtaxa_output)
-blast_output <-               readRDS(blast_output)
-seqtab <-                     readRDS(seqtab)
+idtaxa_output <-             readr::read_csv(idtaxa_output)
+blast_output <-              readr::read_csv(blast_output)
+# seqtab_tibble <-              readr::read_csv(seqtab_tibble)
 
-# merge idtaxa outputs
-if ( length(idtaxa_output) == 1 ) {
-    idtaxa_output <- idtaxa_output[[1]]
-} else if( length(idtaxa_output) == 2 ) {
-    idtaxa_output <- coalesce_tax(idtaxa_output[[1]], idtaxa_output[[2]])
-} else if( length(idtaxa_output) == 3 ) {
-    temptax <- coalesce_tax(idtaxa_output[[1]], idtaxa_output[[2]])
-    idtaxa_output <- coalesce_tax(temptax, idtaxa_output[[3]])
-}
-
-# Check that idtaxa_output dimensions match input
-if(!all(rownames(idtaxa_output) %in% colnames(seqtab))){
-    stop("Number of ASVs classified does not match the number of input ASVs [idtaxa_output]")
-}
-
-# merge blast outputs
-if( length(blast_output) == 1 ) {
-    blast_output <- blast_output[[1]]
-} else if( length(blast_output) == 2 ) {
-    blast_output <- coalesce_tax(blast_output[[1]], blast_output[[2]])
-} else if( length(blast_output) == 3 ) {
-    temptax <- coalesce_tax(blast_output[[1]], blast_output[[2]])
-    blast_output <- coalesce_tax(temptax, blast_output[[3]])
-}
-
-# Check that blast_output dimensions match input
-if(!all(rownames(blast_output) %in% colnames(seqtab))){
-    stop("Number of ASVs classified does not match the number of input ASVs [blast_output]")
-}
-
-# another check
-if(!all(rownames(idtaxa_output) %in% rownames(blast_output))){
-    stop("ASVs in idtaxa_output and blast_output do not match")
+# check that BLAST ASVs are those in IDTAXA ASVs
+if(!all(blast_output$seq_name %in% idtaxa_output$seq_name)){
+    stop("ASV names in BLAST output don't match those in IDTAXA output")
 }
 
 # try to merge IDTAXA and BLAST assignments
+# NOTE: BLAST assignment will only be used if it matches IDTAXA at Genus rank and the IDTAXA Species assignment is NA
 if(nrow(idtaxa_output) > 0 & nrow(blast_output) > 0){
-    #Set BLAST ids where idtaxa_output isn't at genus level to NA
-    disagreements <- !blast_output[,1] == idtaxa_output[,7]
-    disagreements[is.na(disagreements)] <- TRUE
-    blast_output[,1][disagreements] <- NA
-    blast_output[,2][disagreements] <- NA
-    
-    # Join the two taxonomies, prefering names from the tax
-    tax_blast <- coalesce_tax(idtaxa_output, blast_output)
-
-    if ( propagate_tax ) {
-        tax_blast <- tax_blast %>%
-            seqateurs::na_to_unclassified() # Propagate high order ranks to unassigned ASVs
-    }
+    # join idtaxa and blast output together
+    joint_assignment <- 
+        dplyr::full_join(idtaxa_output, blast_output, by = dplyr::join_by(seq_name)) %>%
+        dplyr::mutate(
+            # if idtaxa hasn't assigned to Genus level, then set blast assignment to NA
+            blast_genus = dplyr::if_else(is.na(Genus), NA, blast_genus),
+            blast_spp = dplyr::if_else(is.na(Genus), NA, blast_spp),
+            # if blast genus doesn't match idtaxa genus, set former (and blast_spp) to NA
+            blast_genus = dplyr::if_else(Genus != blast_genus, NA, blast_genus),
+            blast_spp = dplyr::if_else(Genus != blast_genus, NA, blast_spp)
+        ) %>%
+        # work out the matching between idtaxa and blast assignments at genus and species ranks
+        dplyr::mutate(
+            species_match = dplyr::case_when(
+                is.na(Species) & is.na(blast_spp) ~ "both_NA",
+                is.na(Species) & (!is.na(blast_spp)) ~ "idtaxa_NA",
+                (!is.na(Species)) & is.na(blast_spp) ~ "blast_NA",
+                Species == blast_spp ~ "yes"
+            )
+        ) %>%
+        # replace species assignment with BLAST assignment if species_match == "idtaxa_NA"
+        dplyr::mutate(Species = dplyr::if_else(species_match == "idtaxa_NA", blast_spp, Species)) %>%
+        # keep only taxon rank columns + seq_name
+        dplyr::select(seq_name, Root, Kingdom, Phylum, Class, Order, Family, Genus, Species) %>%
+        # replace "NA" taxa with the lowest assigned rank in the "G__Genus" format
+        dplyr::mutate(
+            # unsure Root is always "Root"
+            Root = "Root",
+            # determine the lowest assigned rank, choosing the first true case
+            lowest_assignment = dplyr::case_when(
+                is.na(Kingdom)  ~ paste0("R__",Root),
+                is.na(Phylum)   ~ paste0("K__",Kingdom),
+                is.na(Class)    ~ paste0("P__",Phylum),
+                is.na(Order)    ~ paste0("C__",Class),
+                is.na(Family)   ~ paste0("O__",Order),
+                is.na(Genus)    ~ paste0("F__",Family),
+                is.na(Species)  ~ paste0("G__",Genus),
+                .default        = NA
+            ),
+            # replace NA ranks with the "G__Genus" format ('propagate')
+            dplyr::across(
+                Kingdom:Species, 
+                ~dplyr::case_when(
+                    is.na(.) & !is.na(lowest_assignment) ~ lowest_assignment, 
+                    .default = .
+                )
+            )
+        ) %>%
+        dplyr::select(-lowest_assignment)
 } else {
-    warning("Either idtaxa_output or blast_output is empty")
-    tax_blast <- as.matrix(idtaxa_output)
+    stop("Either idtaxa_output or blast_output is empty")
 }
 
 # another check
-if ( !all(rownames(idtaxa_output) %in% rownames(tax_blast)) ) {
-    stop("Number of ASVs output does not match the number of input ASVs")
+if(!all(idtaxa_output$seq_name %in% joint_assignment$seq_name)){
+    stop("Not all input ASVs are in the joint assignment output")
 }
 
-# Write taxonomy table for that db to disk
-saveRDS(tax_blast, paste0(fcid,"_",pcr_primers,"_taxblast.rds"))
+# Write tibble
+readr::write_csv(joint_assignment, paste0(fcid,"_",pcr_primers,"_joint.csv"))
 

--- a/bin/joint_tax.R
+++ b/bin/joint_tax.R
@@ -31,12 +31,14 @@ idtaxa_output <-
     idtaxa_list %>%
     stringr::str_split_1(., pattern = " ") %>% # split string of filenames into vector
     lapply(., readr::read_csv) %>% # read in seqtabs and store as list of tibbles
+    purrr::keep(., ~ nrow(.x) > 0) %>% # remove tibbles with 0 rows
     dplyr::bind_rows()
 
 blast_output <- 
     blast_list %>%
     stringr::str_split_1(., pattern = " ") %>% # split string of filenames into vector
     lapply(., readr::read_csv) %>% # read in seqtabs and store as list of tibbles
+    purrr::keep(., ~ nrow(.x) > 0) %>% # remove tibbles with 0 rows
     dplyr::bind_rows()
 
 # check that BLAST ASVs are those in IDTAXA ASVs

--- a/bin/joint_tax.R
+++ b/bin/joint_tax.R
@@ -17,8 +17,7 @@ nf_vars <- c(
     "pcr_primers",
     "target_gene",
     "idtaxa_output",
-    "blast_output",
-    "seqtab_tibble"
+    "blast_output"
 )
 lapply(nf_vars, nf_var_check)
 
@@ -27,10 +26,9 @@ target_gene <-          parse_nf_var_repeat(target_gene)
 
 propagate_tax <-        TRUE
 
-### run R code      # derived from step_join_tax_blast() in functions.R and tar_target(joint_tax)
+### run R code      
 idtaxa_output <-             readr::read_csv(idtaxa_output)
 blast_output <-              readr::read_csv(blast_output)
-# seqtab_tibble <-              readr::read_csv(seqtab_tibble)
 
 # check that BLAST ASVs are those in IDTAXA ASVs
 if(!all(blast_output$seq_name %in% idtaxa_output$seq_name)){

--- a/bin/joint_tax.R
+++ b/bin/joint_tax.R
@@ -16,8 +16,8 @@ nf_vars <- c(
     "fcid",
     "pcr_primers",
     "target_gene",
-    "idtaxa_output",
-    "blast_output"
+    "idtaxa_list",
+    "blast_list"
 )
 lapply(nf_vars, nf_var_check)
 
@@ -27,8 +27,17 @@ target_gene <-          parse_nf_var_repeat(target_gene)
 propagate_tax <-        TRUE
 
 ### run R code      
-idtaxa_output <-             readr::read_csv(idtaxa_output)
-blast_output <-              readr::read_csv(blast_output)
+idtaxa_output <- 
+    idtaxa_list %>%
+    stringr::str_split_1(., pattern = " ") %>% # split string of filenames into vector
+    lapply(., readr::read_csv) %>% # read in seqtabs and store as list of tibbles
+    dplyr::bind_rows()
+
+blast_output <- 
+    blast_list %>%
+    stringr::str_split_1(., pattern = " ") %>% # split string of filenames into vector
+    lapply(., readr::read_csv) %>% # read in seqtabs and store as list of tibbles
+    dplyr::bind_rows()
 
 # check that BLAST ASVs are those in IDTAXA ASVs
 if(!all(blast_output$seq_name %in% idtaxa_output$seq_name)){

--- a/bin/make_seqtab_paired.R
+++ b/bin/make_seqtab_paired.R
@@ -163,4 +163,45 @@ sapply(mergers, getN) %>%
     readr::write_csv(., paste0("dada_mergereads_",fcid,"_",pcr_primers,"_readsout.csv"))
 
 
+
+##### make new outputs ----------------------------------------------------------------------------
+
+
+### convert DADA2 format sequence table to both .fasta of sequences with hashes and .csv of sample abundances
+
+# sequences as vector
+seq_vec <- seqtab %>% dada2::getSequences()
+
+# sequences as hash
+hash_vec <- seq_vec %>% lapply(., rlang::hash) %>% unlist()
+
+# named vector of sequences
+names(seq_vec) <- hash_vec
+
+# named DSS
+seq_DSS <- Biostrings::DNAStringSet(seq_vec)
+
+# tibble of hash and seq
+seq_tibble <- tibble::enframe(seq_vec, name = "seq_name", value = "sequence")
+
+# convert seqtab to one row per sequence, ID with hash
+seqtab_tibble <- 
+    seqtab %>% 
+    tidyr::as_tibble(rownames = "sample_id") %>%
+    tidyr::pivot_longer(cols = !sample_id, names_to = "sequence", values_to = "abundance") %>%
+    # join to seq_tibble
+    dplyr::left_join(., seq_tibble, by = "sequence") %>%
+    dplyr::select(-sequence) %>% # remove sequence
+    tidyr::pivot_wider(names_from = sample_id, values_from = abundance)
+
+
+# save DSS as .fasta
+write_fasta(seq_DSS, file = paste0(fcid, "_", pcr_primers, "_seqs.fasta"))
+
+# save seqtab_tidy as .csv
+readr::write_csv(seqtab_tibble, paste0(fcid, "_", pcr_primers, "_seqtab_tibble.csv"))
+
+
+
+
 # stop(" *** stopped manually *** ") ##########################################

--- a/bin/make_seqtab_paired.R
+++ b/bin/make_seqtab_paired.R
@@ -192,6 +192,8 @@ seqtab_tibble <-
     # join to seq_tibble
     dplyr::left_join(., seq_tibble, by = "sequence") %>%
     dplyr::select(-sequence) %>% # remove sequence
+    # add pcr_primers to sample_id
+    dplyr::mutate(sample_id = paste0(sample_id,"_",pcr_primers)) %>%
     tidyr::pivot_wider(names_from = sample_id, values_from = abundance)
 
 

--- a/bin/make_seqtab_paired.R
+++ b/bin/make_seqtab_paired.R
@@ -140,7 +140,7 @@ if ( concat_unmerged ) {
 # Construct sequence table for fcid x pcr_primers from merged reads per sample
 seqtab <- dada2::makeSequenceTable(mergers)
 
-saveRDS(seqtab, paste0(fcid,"_",pcr_primers,"_seqtab.rds"))
+# saveRDS(seqtab, paste0(fcid,"_",pcr_primers,"_seqtab.rds"))
 
 # save number of merged reads per sample
 getN <- function(x) sum(dada2::getUniques(x))

--- a/bin/make_seqtab_single.R
+++ b/bin/make_seqtab_single.R
@@ -109,6 +109,8 @@ seqtab_tibble <-
     # join to seq_tibble
     dplyr::left_join(., seq_tibble, by = "sequence") %>%
     dplyr::select(-sequence) %>% # remove sequence
+    # add pcr_primers to sample_id
+    dplyr::mutate(sample_id = paste0(sample_id,"_",pcr_primers)) %>%
     tidyr::pivot_wider(names_from = sample_id, values_from = abundance)
 
 

--- a/bin/make_seqtab_single.R
+++ b/bin/make_seqtab_single.R
@@ -81,4 +81,42 @@ sapply(seqs_extracted, getN) %>%
     readr::write_csv(., paste0("dada_mergereads_",fcid,"_",pcr_primers,"_readsout.csv"))
 
 
+##### make new outputs ----------------------------------------------------------------------------
+
+
+### convert DADA2 format sequence table to both .fasta of sequences with hashes and .csv of sample abundances
+
+# sequences as vector
+seq_vec <- seqtab %>% dada2::getSequences()
+
+# sequences as hash
+hash_vec <- seq_vec %>% lapply(., rlang::hash) %>% unlist()
+
+# named vector of sequences
+names(seq_vec) <- hash_vec
+
+# named DSS
+seq_DSS <- Biostrings::DNAStringSet(seq_vec)
+
+# tibble of hash and seq
+seq_tibble <- tibble::enframe(seq_vec, name = "seq_name", value = "sequence")
+
+# convert seqtab to one row per sequence, ID with hash
+seqtab_tibble <- 
+    seqtab %>% 
+    tidyr::as_tibble(rownames = "sample_id") %>%
+    tidyr::pivot_longer(cols = !sample_id, names_to = "sequence", values_to = "abundance") %>%
+    # join to seq_tibble
+    dplyr::left_join(., seq_tibble, by = "sequence") %>%
+    dplyr::select(-sequence) %>% # remove sequence
+    tidyr::pivot_wider(names_from = sample_id, values_from = abundance)
+
+
+# save DSS as .fasta
+write_fasta(seq_DSS, file = paste0(fcid, "_", pcr_primers, "_seqs.fasta"))
+
+# save seqtab_tidy as .csv
+readr::write_csv(seqtab_tibble, paste0(fcid, "_", pcr_primers, "_seqtab_tibble.csv"))
+
+
 # stop(" *** stopped manually *** ") ##########################################

--- a/bin/phyloseq_filter.R
+++ b/bin/phyloseq_filter.R
@@ -241,12 +241,12 @@ write_fasta(seqs_output, paste0("asvs_unfiltered_", pcr_primers, ".fasta"))
 
 ## output phyloseq and component data; from step_output_ps
 
-# save seqtab as wide tibble (rows = sample_id, cols = OTU name (hash), cells = abundance)
+# save seqtab as wide tibble (rows = sample_id, cols = ASV name (hash), cells = abundance)
 seqtab_out <- phyloseq::otu_table(ps_sampfiltered) %>%
     as("matrix") %>%
     tibble::as_tibble(rownames = "sample_id")
 
-# save taxtab as long tibble (rows = OTU/ASV, cols = tax rankings)
+# save taxtab as long tibble (rows = ASV, cols = tax rankings)
 taxtab_out <- phyloseq::tax_table(ps_sampfiltered) %>%
     as("matrix") %>%
     tibble::as_tibble(rownames = "seq_name") %>%

--- a/bin/phyloseq_merge.R
+++ b/bin/phyloseq_merge.R
@@ -73,12 +73,12 @@ summarise_phyloseq(ps_u) %>%
 
 ## output phyloseq and component data; from step_output_ps
 
-# save seqtab as wide tibble (rows = sample_id, cols = OTU name (hash), cells = abundance)
+# save seqtab as wide tibble (rows = sample_id, cols = ASV name (hash), cells = abundance)
 seqtab_out_u <- phyloseq::otu_table(ps_u) %>%
     as("matrix") %>%
     tibble::as_tibble(rownames = "sample_id")
 
-# save taxtab as long tibble (rows = OTU/ASV, cols = tax rankings)
+# save taxtab as long tibble (rows = ASV, cols = tax rankings)
 taxtab_out_u <- phyloseq::tax_table(ps_u) %>%
     as("matrix") %>%
     tibble::as_tibble(rownames = "seq_name") %>%
@@ -149,12 +149,12 @@ summarise_phyloseq(ps_f) %>%
 
 ## output phyloseq and component data; from step_output_ps
 
-# save seqtab as wide tibble (rows = sample_id, cols = OTU name (hash), cells = abundance)
+# save seqtab as wide tibble (rows = sample_id, cols = ASV name (hash), cells = abundance)
 seqtab_out_f <- phyloseq::otu_table(ps_f) %>%
     as("matrix") %>%
     tibble::as_tibble(rownames = "sample_id")
 
-# save taxtab as long tibble (rows = OTU/ASV, cols = tax rankings)
+# save taxtab as long tibble (rows = ASV, cols = tax rankings)
 taxtab_out_f <- phyloseq::tax_table(ps_f) %>%
     as("matrix") %>%
     tibble::as_tibble(rownames = "seq_name") %>%

--- a/bin/phyloseq_unfiltered.R
+++ b/bin/phyloseq_unfiltered.R
@@ -190,6 +190,13 @@ melt_phyloseq(ps_uf) %>%
 
 # export summary .csv from phyloseq object
 summarise_phyloseq(ps_uf) %>%
+    dplyr::left_join(
+        .,
+        seqtab_combined %>% 
+            dplyr::select(seq_name, sequence, chimera_filter, length_filter, phmm_filter, frame_filter),
+        by = c("seq_name", "sequence")
+    ) %>%
+    dplyr::relocate(seq_name, sequence, Root:Species, chimera_filter:frame_filter) %>%
     readr::write_csv(., paste0("summary_unfiltered_",pcr_primers,".csv"))
 
 # export phyloseq object

--- a/bin/phyloseq_unfiltered.R
+++ b/bin/phyloseq_unfiltered.R
@@ -22,106 +22,178 @@ invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn
 nf_vars <- c(
     "projectDir",
     "pcr_primers",
-    "taxtab",
+    "taxtab_file",
     "seqtab_list",
+    "fasta_list",
     "loci_params",
     "samdf"
 )
 lapply(nf_vars, nf_var_check)
 
 ## check and define variables
-taxtab <- readRDS(taxtab)
-taxtab %>% # save for debugging
-    tibble::as_tibble(rownames = "OTU") %>%
-    readr::write_csv(., paste0("taxtab_", pcr_primers, ".csv")) 
+taxtab <- readr::read_csv(taxtab_file)
 
-seqtab_list <- # convert Groovy to R list format
-    stringr::str_extract_all(seqtab_list, pattern = "[^\\s,\\[\\]]+") %>% unlist()
-seqtab_list <- lapply(seqtab_list, readRDS) # read in seqtabs and store as list of matrices
+seqtab_list <- 
+    seqtab_list %>%
+    stringr::str_split_1(., pattern = " ") %>% # split string of filenames into vector
+    lapply(., readr::read_csv) # read in seqtabs and store as list of tibbles
+
+fasta_list <- 
+    fasta_list %>%
+    stringr::str_split_1(., pattern = " ") %>% # split string of filenames into vector
+    lapply(., Biostrings::readDNAStringSet)
 
 samdf <- readr::read_csv(samdf, show_col_types = FALSE)
 
 ### run R code
 
-## merge sequence tables across flowcells and loci
-if ( length(seqtab_list) > 1 ){ # if there is more than one seqtab, merge together
-    seqtab_final <- dada2::mergeSequenceTables(tables=seqtab_list)
-} else if( length(seqtab_list) == 1 ) { # if there is only one seqtab, keep and unlist
-    seqtab_final <- seqtab_list[[1]]
+
+# combine seqtab tibbles
+seqtab_combined <- 
+    seqtab_list %>%
+    # pivot each tibble longer
+    lapply(
+        .,
+        function(x){ # per tibble
+            x %>%
+                tidyr::pivot_longer(
+                cols = !c(seq_name, sequence, chimera_filter, length_filter, phmm_filter, frame_filter),
+                names_to = "sample_id",
+                values_to = "abundance"
+                )
+        }
+    ) %>%
+    # bind tibbles together now columns all match
+    dplyr::bind_rows() %>%
+    # pivot wider, filling missing abundance with 0
+    tidyr::pivot_wider(
+        names_from = sample_id,
+        values_from = abundance, 
+        values_fill = 0
+    )
+
+# combine fasta DSS objects, removing redundant sequences
+seqs_combined <- 
+    fasta_list %>%
+    lapply(., as.character) %>%
+    unlist(use.names = T) %>% 
+    .[!duplicated(.)] %>%
+    Biostrings::DNAStringSet()
+
+## check taxonomy, seqtab and fasta all have the same sequences, none are missing
+if(!setequal(taxtab$seq_name, seqtab_combined$seq_name)){
+    stop("taxtab and seqtab_combined do not contain the exact same sequence names")
 }
-seqtab_final %>% # save for debugging
-    tibble::as_tibble(rownames = "OTU") %>% 
-    readr::write_csv(., paste0("seqtab_final_", pcr_primers, ".csv"))
+if(!setequal(taxtab$seq_name, names(seqs_combined))){
+    stop("taxtab and seqs_combined do not contain the exact same sequence names")
+}
+if(!setequal(names(seqs_combined), seqtab_combined$seq_name)){
+    stop("seqs_combined and seqtab_combined do not contain the exact same sequence names")
+}
 
 ## mutate samdf to add pcr_primers to sample_id, to make consistent with new seqtab format
-samdf_renamed <- samdf %>% 
+samdf_renamed <- 
+    samdf %>% 
     dplyr::mutate(
         sample_id_orig = sample_id, # save original sample_id as a new column
         sample_id = paste0(sample_id,"_",pcr_primers) # mutate sample_id to add primer id at the end
-        )
+    )
 
-## run step_phyloseq() on merged seqtabs, taxtabs and samplesheet to create phyloseq object
-ps <- step_phyloseq(
-    seqtab = seqtab_final,
-    taxtab = taxtab,
-    samdf = samdf_renamed,
-    seqs = NULL,
-    phylo = NULL,
-    name_variants = FALSE
-)
+# create phyloseq-format otu_table (seqtab), ignoring filters -- ASV names are rows
+otutab_ps <-   
+    seqtab_combined %>%
+    dplyr::select(-c(sequence, chimera_filter, length_filter, phmm_filter, frame_filter)) %>%
+    tibble::column_to_rownames(var = "seq_name") %>%
+    as.matrix() %>%
+    phyloseq::otu_table(taxa_are_rows = TRUE)
 
-## name OTUs using hash
-phyloseq::taxa_names(ps) <- phyloseq::tax_table(ps)[,ncol(phyloseq::tax_table(ps))] # use final column of tax_table (hash) to name OTUs
-phyloseq::tax_table(ps) <- phyloseq::tax_table(ps)[,1:ncol(phyloseq::tax_table(ps))-1] # remove hash 'rank' from tax_table
+# create dada2-format taxtab
+taxtab_ps <-
+    taxtab %>%
+    tibble::column_to_rownames(var = "seq_name") %>%
+    as.matrix() %>%
+    phyloseq::tax_table()
 
-## output summaries; from step_output_summary()
-# Export raw csv  - NOTE: This is memory intensive
-melt_phyloseq(ps) %>%
+# create sample information phyloseq object
+samples_ps <-
+    samdf_renamed %>%
+    as.data.frame() %>%
+    magrittr::set_rownames(.$sample_id) %>%
+    phyloseq::sample_data()
+
+# create refseq object
+refseq_ps <- 
+    seqs_combined %>%
+    phyloseq::refseq()
+
+
+## create phyloseq object
+ps_uf <- 
+    phyloseq::phyloseq(
+        otutab_ps, 
+        taxtab_ps,
+        samples_ps,
+        refseq_ps
+    )
+
+### outputs -----------------------------------------------------------------------------
+
+# save sequences as .fasta file (with taxonomy in header, in format "seq_name|pcr_primers;Root;Kingdom;Phylum;Class;Order;Family;Genus;Species")
+seq_names_new <- 
+    taxtab %>%
+    # ensure sequence name order is same as the DSS object
+    dplyr::arrange(factor(seq_name, levels = names(seqs_combined))) %>%
+    # add pcr_primers
+    dplyr::mutate(pcr_primers = pcr_primers, .after = seq_name) %>%
+    # unite columns into a single header string per sequence
+    tidyr::unite(col = "lineage", Root:Species, sep = ";") %>%
+    tidyr::unite(col = "id", c(seq_name, pcr_primers), sep = "|") %>%
+    tidyr::unite(col = "header", c(id, lineage), sep = ";") %>%
+    dplyr::pull(header)
+
+seqs_output <- seqs_combined
+
+names(seqs_output) <- seq_names_new
+
+write_fasta(seqs_output, paste0("asvs_unfiltered_", pcr_primers, ".fasta"))  
+
+# save seqtab (filters) as wide tibble (rows = seq_name, columns = sample_id)
+seqtab_combined %>%
+    dplyr::select(seq_name, sequence, chimera_filter, length_filter, phmm_filter, frame_filter) %>%
+    readr::write_csv(., paste0("filters_",pcr_primers,".csv"))
+
+# save seqtab (data) as wide tibble (rows = seq_name, columns = sample_id)
+phyloseq::otu_table(ps_uf) %>%
+    as("matrix") %>%
+    tibble::as_tibble(rownames = "seq_name") %>%
+    readr::write_csv(., paste0("seqtab_unfiltered_",pcr_primers,".csv"))
+
+# save taxtab as tibble (rows = seq_name, columns = taxonomic ranks (Root -> Species))
+phyloseq::tax_table(ps_uf) %>%
+    as("matrix") %>%
+    tibble::as_tibble(rownames = "seq_name") %>%
+    # convert propagated taxonomy to NA values
+    dplyr::mutate( 
+        dplyr::across(Root:Species, ~ dplyr::if_else(stringr::str_detect(.x, "^\\w__"), NA, .x))
+    ) %>%
+    readr::write_csv(., paste0("taxtab_unfiltered_",pcr_primers,".csv"))
+
+# save samdf as tibble
+phyloseq::sample_data(ps_uf) %>%
+    as("matrix") %>%
+    tibble::as_tibble() %>%
+    readr::write_csv(., paste0("samdf_unfiltered_",pcr_primers,".csv"))
+
+# export raw .csv from phyloseq object
+melt_phyloseq(ps_uf) %>%
     readr::write_csv(., paste0("raw_unfiltered_",pcr_primers,".csv"))
 
-# Export species level summary of filtered results
-summarise_phyloseq(ps) %>%
+# export summary .csv from phyloseq object
+summarise_phyloseq(ps_uf) %>%
     readr::write_csv(., paste0("summary_unfiltered_",pcr_primers,".csv"))
 
-# Output fasta of all ASVs
-Biostrings::writeXStringSet(phyloseq::refseq(ps), filepath = paste0("asvs_unfiltered_",pcr_primers,".fasta"), width = 100) 
-
-# write .nwk file if phylogeny present
-if(!is.null(phyloseq::phy_tree(ps, errorIfNULL = FALSE))){
-    #Output newick tree
-    ape::write.tree(phyloseq::phy_tree(ps), file = paste0("tree_unfiltered",pcr_primers,".nwk"))
-}
-
-## output phyloseq and component data; from step_output_ps
-
-# save seqtab as wide tibble (rows = sample_id, cols = OTU name (hash), cells = abundance)
-seqtab_out <- phyloseq::otu_table(ps) %>%
-    as("matrix") %>%
-    tibble::as_tibble(rownames = "sample_id")
-
-# save taxtab as long tibble (rows = OTU/ASV, cols = tax rankings)
-taxtab_out <- phyloseq::tax_table(ps) %>%
-    as("matrix") %>%
-    tibble::as_tibble(rownames = "OTU") %>%
-    seqateurs::unclassified_to_na(rownames = FALSE)
-
-# Check taxonomy table outputs
-### TODO: use 'ranks' pipeline parameter (from loci_params?) to set this explicitly rather than guessing
-if(!all(colnames(taxtab_out) == c("OTU", "Root", "Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species"))){
-    message("Warning: Taxonomy table columns do not meet expectations for the staging database \n
-            Database requires the columns: OTU, Root, Kingdom, Phylum, Class, Order, Family, Genus, Species ")
-}
-
-# save samplesheet
-samdf_out <- phyloseq::sample_data(ps) %>%
-    as("matrix") %>%
-    tibble::as_tibble()
-
-# Write out
-readr::write_csv(seqtab_out, paste0("seqtab_unfiltered_",pcr_primers,".csv"))
-readr::write_csv(taxtab_out, paste0("taxtab_unfiltered_",pcr_primers,".csv"))
-readr::write_csv(samdf_out, paste0("samdf_unfiltered_",pcr_primers,".csv"))
-saveRDS(ps, paste0("ps_unfiltered_",pcr_primers,".rds"))
+# export phyloseq object
+saveRDS(ps_uf, paste0("ps_unfiltered_",pcr_primers,".rds"))
 
 # ## creates accumulation curve plots and saves plot
 # gg.acc_curve <- rareplot(ps, step=1L, threshold = max(samdf$min_sample_reads))

--- a/bin/phyloseq_unfiltered.R
+++ b/bin/phyloseq_unfiltered.R
@@ -195,11 +195,4 @@ summarise_phyloseq(ps_uf) %>%
 # export phyloseq object
 saveRDS(ps_uf, paste0("ps_unfiltered_",pcr_primers,".rds"))
 
-# ## creates accumulation curve plots and saves plot
-# gg.acc_curve <- rareplot(ps, step=1L, threshold = max(samdf$min_sample_reads))
-
-# pdf(file=paste0("accumulation_curve_",pcr_primers,".pdf"), width = 11, height = 8 , paper="a4r")
-#     print(gg.acc_curve)
-# try(dev.off(), silent=TRUE)
-
 # stop(" *** stopped manually *** ") ##########################################

--- a/bin/tax_idtaxa.R
+++ b/bin/tax_idtaxa.R
@@ -19,7 +19,6 @@ nf_vars <- c(
     "projectDir",
     "fcid",
     "pcr_primers",
-    # "seqtab",
     "idtaxa_confidence",
     "idtaxa_db",
     "fasta"

--- a/bin/tax_summary.R
+++ b/bin/tax_summary.R
@@ -16,8 +16,8 @@ nf_vars <- c(
     "projectDir",
     "pcr_primers",
     "fcid",
-    "tax",
-    "ids",
+    "tax_file",
+    "ids_file",
     "joint_file",
     "target_gene",
     "idtaxa_db",
@@ -26,52 +26,57 @@ nf_vars <- c(
 lapply(nf_vars, nf_var_check)
 
 ## check and define variables
-idtaxa <-       readRDS(tax)
-idtaxa_ids <-   readRDS(ids)
+idtaxa_tax <-   readr::read_csv(tax_file)
+idtaxa_ids <-   readRDS(ids_file)
 joint <-        readRDS(joint_file)
-# TODO: deal with case where 'joint' does not exist due to BLAST not being performed
-# in these cases, set 'joint' to NULL
 
-# TODO: use explicitly defined ranks from IDTAXA database instead of guess
+# TODO: use explicitly defined ranks from ref fasta database or parameter instead of guess
 ranks <- c("Root","Kingdom", "Phylum","Class", "Order", "Family", "Genus","Species")
 
 ### run R code
-OTU_seq <- rownames(idtaxa) # get OTU sequences as vector
-OTU_hash <- lapply(OTU_seq, rlang::hash) %>% unlist() # get unique hash for each OTU sequence
+idtaxa_summary <- 
+  idtaxa_ids %>%
+    # transform "Taxa" data frame, one row at a time
+    purrr::imap_dfr(function(x, idx){
+        # get assigned taxa as vector
+        taxa <- paste0(x$taxon, "_", x$confidence)
+        # make unclassified taxa NA
+        taxa[startsWith(taxa, "unclassified_")] <- NA
+        # make a data frame with the ranks as columns and taxa as values, seq_name as column too
+        out_df <- 
+            data.frame(t(taxa)) %>% 
+            magrittr::set_colnames(ranks[1:ncol(.)]) %>%
+            dplyr::mutate(seq_name = idx) %>%
+            dplyr::relocate(seq_name)
 
-idtaxa_summary <- idtaxa_ids %>%
-    purrr::map_dfr(function(x){
-        taxa <- paste0(x$taxon,"_", x$confidence) # add assignment confidence to taxon name
-        taxa[startsWith(taxa, "unclassified_")] <- NA # set unclassified ranks to NA
-        data.frame(t(taxa)) %>% # create data frame setting ranks to column names
-            magrittr::set_colnames(ranks[1:ncol(.)])
+        return(out_df)
     }) %>%
-    dplyr::mutate_all(function(y){
-        name <- y %>% stringr::str_remove("_[0-9].*$") # get name of taxon
-        conf <- y %>% stringr::str_remove("^.*_") %>% # get confidence of taxon, truncated to 5 digits (5 + '.')
-            stringr::str_trunc(width=6, side="right", ellipsis = "")
-        paste0(name, "_", conf, "%") # create new taxon name with confidence in % form
-    }) %>%
-    dplyr::mutate_all(~ na_if(., "NA_NA%")) %>% # convert 'NA_NA%' into true NAs
     dplyr::mutate(
-        OTU_seq = OTU_seq, # add OTU sequence as column
-        OTU_hash = OTU_hash # add OTU sequence hash as column
+      # add confidence as % to end of taxon name
+      dplyr::across(Root:Species, ~{
+        tax_name <- .x %>% stringr::str_remove("_[0-9]+.*$")
+        tax_conf <- .x %>% stringr::str_remove(paste0(tax_name,"_")) %>% as.numeric() %>% round(., digits = 1)
+        return(paste0(tax_name, "__", tax_conf, "%"))
+      }),
+      # convert "NA__NA%" into true NA
+      dplyr::across(Root:Species, ~ dplyr::na_if(.x, "NA__NA%"))
+    ) %>%
+    # add ASV sequence
+    dplyr::left_join(., joint %>% dplyr::select(seq_name, sequence), by = "seq_name") %>%
+    dplyr::relocate(seq_name, sequence) %>%
+     # add metadata
+    dplyr::mutate(
+        pcr_primers = pcr_primers,
+        target_gene = target_gene,
+        idtaxa_db = idtaxa_db,
+        ref_fasta = ref_fasta,
     )
 
 if(!is.null(joint)){
-    blast_summary <- joint %>% 
-        dplyr::mutate(
-            pcr_primers = pcr_primers,
-            target_gene = target_gene,
-            idtaxa_db = idtaxa_db,
-            ref_fasta = ref_fasta,
-        ) %>% 
+    blast_summary <- 
+      joint %>% 
         dplyr::select(
-            pcr_primers, 
-            target_gene, 
-            idtaxa_db, 
-            ref_fasta, 
-            OTU_seq = OTU, 
+            seq_name,
             acc,  
             blast_top_hit = blastspp, 
             blast_identity = pident,
@@ -80,12 +85,13 @@ if(!is.null(joint)){
             blast_max_score = max_score, 
             blast_qcov = qcovs
         )
-    
-    summary_table <- idtaxa_summary %>%
-        dplyr::left_join(blast_summary) %>%
+
+    summary_table <- 
+      idtaxa_summary %>%
+        dplyr::left_join(., blast_summary, by = "seq_name") %>%
         dplyr::select(tidyselect::any_of(c(
-            "OTU_hash",
-            "OTU_seq", 
+            "seq_name",
+            "sequence", 
             "pcr_primers", 
             "target_gene", 
             "idtaxa_db", 
@@ -107,10 +113,11 @@ if(!is.null(joint)){
         ))
 
 } else {
-    summary_table <- idtaxa_summary %>%
+    summary_table <- 
+      idtaxa_summary %>%
         dplyr::select(tidyselect::any_of(c(
-            "OTU_hash",
-            "OTU_seq", 
+            "seq_name",
+            "sequence", 
             "pcr_primers", 
             "target_gene", 
             "idtaxa_db", 
@@ -132,8 +139,8 @@ if(!is.null(joint)){
         ))
 }
 
-out <- paste0(fcid,"_",pcr_primers,"_taxonomic_assignment_summary.csv")
-readr::write_csv(summary_table, out)
+# write out
+readr::write_csv(summary_table, paste0(fcid,"_",pcr_primers,"_taxonomic_assignment_summary.csv"))
 
 saveRDS(summary_table, paste0(fcid,"_",pcr_primers,"_taxonomic_assignment_summary.rds"))
 

--- a/bin/tax_summary_merge.R
+++ b/bin/tax_summary_merge.R
@@ -18,23 +18,17 @@ nf_vars <- c(
 lapply(nf_vars, nf_var_check)
 
 ## check and define variables
+# read in taxtabs and store as list of tibbles
+ts_merged <- 
+    tax_summary_list %>% 
+    stringr::str_split_1(., pattern = " ") %>% # split string of filenames into vector
+    lapply(., readr::read_csv) %>%
+    dplyr::bind_rows() %>%
+    dplyr::group_by(seq_name) %>%
+    dplyr::slice(1) %>% 
+    dplyr::ungroup() %>%
+    dplyr::arrange(seq_name)
 
-tax_summary_list <- # convert Groovy to R list format
-    stringr::str_extract_all(tax_summary_list, pattern = "[^\\s,\\[\\]]+") %>% unlist()
-
-tax_summary_list <- lapply(tax_summary_list, readRDS) # read in taxtabs and store as list of tibbles
-
-
-### run R code
-summary_full <- tibble::tibble() # create empty tibble
-for (i in 1:length(tax_summary_list)){ # loop through list of tibbles
-    summary_full <- dplyr::bind_rows(summary_full, tax_summary_list[i]) # combine tibbles into one tibble
-}
-
-summary_full <- summary_full %>%
-    dplyr::distinct() %>%  # remove identical rows, leaving one (ie. duplicate sequences between flow cells)
-    dplyr::arrange(OTU_hash) # sort final tibble by OTU_hash
-
-readr::write_csv(summary_full,"taxonomic_assignment_summary.csv") # write to .csv
+readr::write_csv(ts_merged,"taxonomic_assignment_summary.csv") # write to .csv
 
 # stop(" *** stopped manually *** ") ##########################################

--- a/dev_notes/nextflow_notes.md
+++ b/dev_notes/nextflow_notes.md
@@ -139,3 +139,12 @@ Run test data with minimal samples:
 
 
 
+Test with Horsham data (one flowcell, three primer pairs)
+
+    nextflow run . \
+        -profile basc_slurm,debug \
+        --samplesheet /group/pathogens/IAWS/Projects/NGDSI/Horsham/samplesheets/freyr_samplesheet_LM2TV.csv \
+        --loci_params /group/pathogens/IAWS/Projects/NGDSI/Horsham/analysis/loci_params.csv \
+        --lp_idtaxa_db /group/pathogens/IAWS/Personal/JackS/databases/coi/tarth_250307/idtaxa_model.rds \
+        --lp_ref_fasta /group/pathogens/IAWS/Personal/JackS/databases/coi/tarth_250307/final_database.fasta \
+        -resume

--- a/docs/insect_coi.md
+++ b/docs/insect_coi.md
@@ -331,7 +331,7 @@ Detailed taxonomic assignment information for the unfiltered ASV set, merged acr
 
 #### Visualisation and QC plots
 
-The `phyloseq_unfiltered` directory contains **accumulation curve plots** (`accumulation_curve_*.pdf`) that show ASV accumulation curves per sample and flowcell. [not true currently]
+The `accumulation_curve` directory contains **accumulation curve plots** (`accumulation_curve_*.pdf`) that show ASV accumulation curves per sample for a particular primer pair. 
 
 **Taxonomic assignment plots** (`*_taxonomic_assignment_summary.pdf`) can be found in `./output/modules/assignment_plot` and show the relationship between IDTAXA taxonomic assignment level and % identity to the top BLAST hit in the database, per flowcell and PCR primer combination. 
 

--- a/docs/insect_coi.md
+++ b/docs/insect_coi.md
@@ -316,28 +316,28 @@ Currently, the outputs of the pipeline are found in the `./output/modules` direc
 
 #### Sequences, abundances, and taxonomic assignment
 
-Inferred sequences (confusingly currently called both 'ASVs' and 'OTUs' in the pipeline) are filtered per locus/primer pair using the parameters specified in the `loci_params` file. As such, there are both filtered and unfiltered output files, which are found in the `./output/modules/phyloseq_unfiltered` and `./output/modules/phyloseq_filter` directories, respectively. Files in these directories are separated by locus, which is useful if your PCR primers target different genes. In contrast, the `./output/modules/phyloseq_merge` directory contains filtered and unfiltered results merged across primer pairs, which is useful if all your primer pairs target the same gene (eg. tagging technical or biological replicates). 
+Inferred sequences (ASVs) are filtered per locus/primer pair using the parameters specified in the `loci_params` file. As such, there are both filtered and unfiltered output files, which are found in the `./output/modules/phyloseq_unfiltered` and `./output/modules/phyloseq_filter` directories, respectively. Files in these directories are separated by locus, which is useful if your PCR primers target different genes. In contrast, the `./output/modules/phyloseq_merge` directory contains filtered and unfiltered results merged across primer pairs, which is useful if all your primer pairs target the same gene (eg. tagging technical or biological replicates). 
 
 All three of these directories contain the following types of files (where `*` is a variable part of the file name):
-- `asvs_*.fasta`: FastA file of OTU/ASV sequences
-- `taxtab_*.csv`: taxonomic assignment of each OTU/ASV (name, no sequence) for every taxonomic rank
-- `summary_*.csv`: abundance of OTUs/ASVs per sample (wide format), including sequence and taxonomic assignment
-- `seqtab_*.csv`: simple table of OTU/ASV abundance per sample, not containing sequence or taxonomic assignment
+- `asvs_*.fasta`: FastA file of ASV sequences
+- `taxtab_*.csv`: taxonomic assignment of each ASV (name, no sequence) for every taxonomic rank
+- `summary_*.csv`: abundance of ASVs per sample (wide format), including sequence and taxonomic assignment
+- `seqtab_*.csv`: simple table of ASV abundance per sample, not containing sequence or taxonomic assignment
 - `samdf_*.csv`: samplesheets, split by primer pair, containing input metadata; samples removed during filtering will be missing from the `filtered` versions of this file
-- `raw_*.csv`: large file of sample-level abundance per OTU/ASV (long format), including samplesheet metadata, loci parameters and taxonomic assignment (but not sequence)
+- `raw_*.csv`: large file of sample-level abundance per ASV (long format), including samplesheet metadata, loci parameters, taxonomic assignment and sequence
 - `ps_*.rds`: R data files in the [`phyloseq`](https://joey711.github.io/phyloseq/) format 
 
-Detailed taxonomic assignment information for the unfiltered OTU/ASV set, merged across primer pairs, can also be found in `./output/modules/tax_summary_merge` in the `taxonomic_assignment_summary.csv` file. This includes the OTU/ASV name, sequence, primer pair, taxonomic assignment confidence per rank, and the identity of the top BLAST hit in the reference database. 
+Detailed taxonomic assignment information for the unfiltered ASV set, merged across primer pairs, can also be found in `./output/modules/tax_summary_merge` in the `taxonomic_assignment_summary.csv` file. This includes the ASV name, sequence, primer pair, taxonomic assignment confidence per rank, and the identity of the top BLAST hit in the reference database. 
 
 #### Visualisation and QC plots
 
-The `phyloseq_unfiltered` directory contains **accumulation curve plots** (`accumulation_curve_*.pdf`) that show OTU/ASV accumulation curves per sample and flowcell. 
+The `phyloseq_unfiltered` directory contains **accumulation curve plots** (`accumulation_curve_*.pdf`) that show ASV accumulation curves per sample and flowcell. [not true currently]
 
 **Taxonomic assignment plots** (`*_taxonomic_assignment_summary.pdf`) can be found in `./output/modules/assignment_plot` and show the relationship between IDTAXA taxonomic assignment level and % identity to the top BLAST hit in the database, per flowcell and PCR primer combination. 
 
-**OTU/ASV filtering plots** (`*_ASV_cleanup_summary.pdf`) can be found in `./output/modules/filter_seqtab` and show the number and abundance of sequences kept or filtered, within each flowcell and PCR primer combination.
+**ASV filtering plots** (`*_ASV_cleanup_summary.pdf`) can be found in `./output/modules/filter_seqtab` and show the number and abundance of sequences kept or filtered, within each flowcell and PCR primer combination.
 
-A **read tracking plot** (`read_tracker.pdf`) can be found in `./output/modules/read_tracking`. This shows the total number of reads, per flowcell, that make it through each step of the pipeline, including the final taxonomic and abundance filtering of OTUs/ASVs. 
+A **read tracking plot** (`read_tracker.pdf`) can be found in `./output/modules/read_tracking`. This shows the total number of reads, per flowcell, that make it through each step of the pipeline, including the final taxonomic and abundance filtering of ASVs. 
 
 **Read quality plots** per sample and primer pair can be found in `./output/modules/filter_qualplots`, that visualise quality before (`*_pre_qualplots.pdf`) and after (`*_post_qualplots.pdf`) read filtering and truncation. These show the distribution of base quality per position (top) and the cumulative number of expected errors per read for various quantiles (bottom).
 

--- a/docs/insect_coi_dpird.md
+++ b/docs/insect_coi_dpird.md
@@ -333,28 +333,28 @@ Currently, the outputs of the pipeline are found in the `./output/modules` direc
 
 #### Sequences, abundances, and taxonomic assignment
 
-Inferred sequences (confusingly currently called both 'ASVs' and 'OTUs' in the pipeline) are filtered per locus/primer pair using the parameters specified in the `loci_params` file. As such, there are both filtered and unfiltered output files, which are found in the `./output/modules/phyloseq_unfiltered` and `./output/modules/phyloseq_filter` directories, respectively. Files in these directories are separated by locus, which is useful if your PCR primers target different genes. In contrast, the `./output/modules/phyloseq_merge` directory contains filtered and unfiltered results merged across primer pairs, which is useful if all your primer pairs target the same gene (eg. tagging technical or biological replicates). 
+Inferred sequences (ASVs) are filtered per locus/primer pair using the parameters specified in the `loci_params` file. As such, there are both filtered and unfiltered output files, which are found in the `./output/modules/phyloseq_unfiltered` and `./output/modules/phyloseq_filter` directories, respectively. Files in these directories are separated by locus, which is useful if your PCR primers target different genes. In contrast, the `./output/modules/phyloseq_merge` directory contains filtered and unfiltered results merged across primer pairs, which is useful if all your primer pairs target the same gene (eg. tagging technical or biological replicates). 
 
 All three of these directories contain the following types of files (where `*` is a variable part of the file name):
-- `asvs_*.fasta`: FastA file of OTU/ASV sequences
-- `taxtab_*.csv`: taxonomic assignment of each OTU/ASV (name, no sequence) for every taxonomic rank
-- `summary_*.csv`: abundance of OTUs/ASVs per sample (wide format), including sequence and taxonomic assignment
-- `seqtab_*.csv`: simple table of OTU/ASV abundance per sample, not containing sequence or taxonomic assignment
+- `asvs_*.fasta`: FastA file of ASV sequences, headers include unique ASV name, primer pair and taxonomic assignment
+- `taxtab_*.csv`: taxonomic assignment of each ASV (name, no sequence) for every taxonomic rank
+- `summary_*.csv`: abundance of ASVs per sample (wide format), including sequence and taxonomic assignment
+- `seqtab_*.csv`: simple table of ASV abundance per sample, not containing sequence or taxonomic assignment
 - `samdf_*.csv`: samplesheets, split by primer pair, containing input metadata; samples removed during filtering will be missing from the `filtered` versions of this file
-- `raw_*.csv`: large file of sample-level abundance per OTU/ASV (long format), including samplesheet metadata, loci parameters and taxonomic assignment (but not sequence)
+- `raw_*.csv`: large file of sample-level abundance per ASV (long format), including samplesheet metadata, loci parameters, taxonomic assignment and nucleotide sequence
 - `ps_*.rds`: R data files in the [`phyloseq`](https://joey711.github.io/phyloseq/) format 
 
-Detailed taxonomic assignment information for the unfiltered OTU/ASV set, merged across primer pairs, can also be found in `./output/modules/tax_summary_merge` in the `taxonomic_assignment_summary.csv` file. This includes the OTU/ASV name, sequence, primer pair, taxonomic assignment confidence per rank, and the identity of the top BLAST hit in the reference database. 
+Detailed taxonomic assignment information for the unfiltered ASV set, merged across primer pairs, can also be found in `./output/modules/tax_summary_merge` in the `taxonomic_assignment_summary.csv` file. This includes the ASV name, sequence, primer pair, taxonomic assignment confidence per rank, and the identity of the top BLAST hit in the reference database. 
 
 #### Visualisation and QC plots
 
-The `phyloseq_unfiltered` directory contains **accumulation curve plots** (`accumulation_curve_*.pdf`) that show OTU/ASV accumulation curves per sample and flowcell. 
+The `phyloseq_unfiltered` directory contains **accumulation curve plots** (`accumulation_curve_*.pdf`) that show ASV accumulation curves per sample and flowcell. 
 
 **Taxonomic assignment plots** (`*_taxonomic_assignment_summary.pdf`) can be found in `./output/modules/assignment_plot` and show the relationship between IDTAXA taxonomic assignment level and % identity to the top BLAST hit in the database, per flowcell and PCR primer combination. 
 
-**OTU/ASV filtering plots** (`*_ASV_cleanup_summary.pdf`) can be found in `./output/modules/filter_seqtab` and show the number and abundance of sequences kept or filtered, within each flowcell and PCR primer combination.
+**ASV filtering plots** (`*_ASV_cleanup_summary.pdf`) can be found in `./output/modules/filter_seqtab` and show the number and abundance of sequences kept or filtered, within each flowcell and PCR primer combination.
 
-A **read tracking plot** (`read_tracker.pdf`) can be found in `./output/modules/read_tracking`. This shows the total number of reads, per flowcell, that make it through each step of the pipeline, including the final taxonomic and abundance filtering of OTUs/ASVs. 
+A **read tracking plot** (`read_tracker.pdf`) can be found in `./output/modules/read_tracking`. This shows the total number of reads, per flowcell, that make it through each step of the pipeline, including the final taxonomic and abundance filtering of ASVs. 
 
 **Read quality plots** per sample and primer pair can be found in `./output/modules/filter_qualplots`, that visualise quality before (`*_pre_qualplots.pdf`) and after (`*_post_qualplots.pdf`) read filtering and truncation. These show the distribution of base quality per position (top) and the cumulative number of expected errors per read for various quantiles (bottom).
 

--- a/docs/insect_coi_dpird.md
+++ b/docs/insect_coi_dpird.md
@@ -348,7 +348,7 @@ Detailed taxonomic assignment information for the unfiltered ASV set, merged acr
 
 #### Visualisation and QC plots
 
-The `phyloseq_unfiltered` directory contains **accumulation curve plots** (`accumulation_curve_*.pdf`) that show ASV accumulation curves per sample and flowcell. 
+The `accumulation_curve` directory contains **accumulation curve plots** (`accumulation_curve_*.pdf`) that show ASV accumulation curves per sample for a particular primer pair. 
 
 **Taxonomic assignment plots** (`*_taxonomic_assignment_summary.pdf`) can be found in `./output/modules/assignment_plot` and show the relationship between IDTAXA taxonomic assignment level and % identity to the top BLAST hit in the database, per flowcell and PCR primer combination. 
 

--- a/docs/nanopore_tutorial.md
+++ b/docs/nanopore_tutorial.md
@@ -341,7 +341,7 @@ Detailed taxonomic assignment information for the unfiltered ASV set, merged acr
 
 #### Visualisation and QC plots
 
-The `phyloseq_unfiltered` directory contains **accumulation curve plots** (`accumulation_curve_*.pdf`) that show ASV accumulation curves per sample and flowcell. [not true currently]
+The `accumulation_curve` directory contains **accumulation curve plots** (`accumulation_curve_*.pdf`) that show ASV accumulation curves per sample for a particular primer pair. 
 
 **Taxonomic assignment plots** (`*_taxonomic_assignment_summary.pdf`) can be found in `./output/modules/assignment_plot` and show the relationship between IDTAXA taxonomic assignment level and % identity to the top BLAST hit in the database, per flowcell and PCR primer combination. 
 

--- a/docs/nanopore_tutorial.md
+++ b/docs/nanopore_tutorial.md
@@ -326,28 +326,28 @@ Currently, the outputs of the pipeline are found in the `./output/modules` direc
 
 #### Sequences, abundances, and taxonomic assignment
 
-Inferred sequences (confusingly currently called both 'ASVs' and 'OTUs' in the pipeline) are filtered per locus/primer pair using the parameters specified in the `loci_params` file. As such, there are both filtered and unfiltered output files, which are found in the `./output/modules/phyloseq_unfiltered` and `./output/modules/phyloseq_filter` directories, respectively. Files in these directories are separated by locus, which is useful if your PCR primers target different genes. In contrast, the `./output/modules/phyloseq_merge` directory contains filtered and unfiltered results merged across primer pairs, which is useful if all your primer pairs target the same gene (eg. tagging technical or biological replicates). 
+Inferred sequences (ASVs) are filtered per locus/primer pair using the parameters specified in the `loci_params` file. As such, there are both filtered and unfiltered output files, which are found in the `./output/modules/phyloseq_unfiltered` and `./output/modules/phyloseq_filter` directories, respectively. Files in these directories are separated by locus, which is useful if your PCR primers target different genes. In contrast, the `./output/modules/phyloseq_merge` directory contains filtered and unfiltered results merged across primer pairs, which is useful if all your primer pairs target the same gene (eg. tagging technical or biological replicates). 
 
 All three of these directories contain the following types of files (where `*` is a variable part of the file name):
-- `asvs_*.fasta`: FastA file of OTU/ASV sequences
-- `taxtab_*.csv`: taxonomic assignment of each OTU/ASV (name, no sequence) for every taxonomic rank
-- `summary_*.csv`: abundance of OTUs/ASVs per sample (wide format), including sequence and taxonomic assignment
-- `seqtab_*.csv`: simple table of OTU/ASV abundance per sample, not containing sequence or taxonomic assignment
+- `asvs_*.fasta`: FastA file of ASV sequences
+- `taxtab_*.csv`: taxonomic assignment of each ASV (name, no sequence) for every taxonomic rank
+- `summary_*.csv`: abundance of ASVs per sample (wide format), including sequence and taxonomic assignment
+- `seqtab_*.csv`: simple table of ASV abundance per sample, not containing sequence or taxonomic assignment
 - `samdf_*.csv`: samplesheets, split by primer pair, containing input metadata; samples removed during filtering will be missing from the `filtered` versions of this file
-- `raw_*.csv`: large file of sample-level abundance per OTU/ASV (long format), including samplesheet metadata, loci parameters and taxonomic assignment (but not sequence)
+- `raw_*.csv`: large file of sample-level abundance per ASV (long format), including samplesheet metadata, loci parameters, taxonomic assignment and sequence
 - `ps_*.rds`: R data files in the [`phyloseq`](https://joey711.github.io/phyloseq/) format 
 
-Detailed taxonomic assignment information for the unfiltered OTU/ASV set, merged across primer pairs, can also be found in `./output/modules/tax_summary_merge` in the `taxonomic_assignment_summary.csv` file. This includes the OTU/ASV name, sequence, primer pair, taxonomic assignment confidence per rank, and the identity of the top BLAST hit in the reference database. 
+Detailed taxonomic assignment information for the unfiltered ASV set, merged across primer pairs, can also be found in `./output/modules/tax_summary_merge` in the `taxonomic_assignment_summary.csv` file. This includes the ASV name, sequence, primer pair, taxonomic assignment confidence per rank, and the identity of the top BLAST hit in the reference database.
 
 #### Visualisation and QC plots
 
-The `phyloseq_unfiltered` directory contains **accumulation curve plots** (`accumulation_curve_*.pdf`) that show OTU/ASV accumulation curves per sample and flowcell. 
+The `phyloseq_unfiltered` directory contains **accumulation curve plots** (`accumulation_curve_*.pdf`) that show ASV accumulation curves per sample and flowcell. [not true currently]
 
 **Taxonomic assignment plots** (`*_taxonomic_assignment_summary.pdf`) can be found in `./output/modules/assignment_plot` and show the relationship between IDTAXA taxonomic assignment level and % identity to the top BLAST hit in the database, per flowcell and PCR primer combination. 
 
-**OTU/ASV filtering plots** (`*_ASV_cleanup_summary.pdf`) can be found in `./output/modules/filter_seqtab` and show the number and abundance of sequences kept or filtered, within each flowcell and PCR primer combination.
+**ASV filtering plots** (`*_ASV_cleanup_summary.pdf`) can be found in `./output/modules/filter_seqtab` and show the number and abundance of sequences kept or filtered, within each flowcell and PCR primer combination.
 
-A **read tracking plot** (`read_tracker.pdf`) can be found in `./output/modules/read_tracking`. This shows the total number of reads, per flowcell, that make it through each step of the pipeline, including the final taxonomic and abundance filtering of OTUs/ASVs. 
+A **read tracking plot** (`read_tracker.pdf`) can be found in `./output/modules/read_tracking`. This shows the total number of reads, per flowcell, that make it through each step of the pipeline, including the final taxonomic and abundance filtering of ASVs. 
 
 **Read quality plots** per sample and primer pair can be found in `./output/modules/filter_qualplots`, that visualise quality before (`*_pre_qualplots.pdf`) and after (`*_post_qualplots.pdf`) read filtering and truncation. These show the distribution of base quality per position (top) and the cumulative number of expected errors per read for various quantiles (bottom). A Nanopore-specific input QC report per sample from [`NanoPlot`](https://github.com/wdecoster/NanoPlot) (`*_NanoPlot-report.html`) can be found in `./output/modules/nanoplot`.
 

--- a/main.nf
+++ b/main.nf
@@ -376,7 +376,7 @@ workflow FREYR {
 
     ///// VISUALISATION
     /*
-    - stacked bar charts of OTU abundance across samples -- filtered vs unfiltered
+    - stacked bar charts of ASV abundance across samples -- filtered vs unfiltered
     - plots showing proportion of sequences that passed or failed the final filters, per sample/flowcell/locus etc
     - taxonomy heatmap tree
     */

--- a/main.nf
+++ b/main.nf
@@ -359,14 +359,13 @@ workflow FREYR {
     TAXONOMY (
         DADA2.out.ch_seqtab,
         ch_loci_params,
-        ch_idtaxa_db_new,
-        DADA2.out.ch_seqtab_new
+        ch_idtaxa_db_new
         )
 
 
     //// subworkflow: create result summaries
     RESULT_SUMMARIES (
-        DADA2.out.ch_seqtab_new,
+        DADA2.out.ch_seqtab,
         TAXONOMY.out.ch_mergetax_output,
         ch_loci_samdf,
         ch_loci_params,

--- a/main.nf
+++ b/main.nf
@@ -366,7 +366,7 @@ workflow FREYR {
 
     //// subworkflow: create result summaries
     RESULT_SUMMARIES (
-        DADA2.out.ch_seqtab,
+        DADA2.out.ch_seqtab_new,
         TAXONOMY.out.ch_mergetax_output,
         ch_loci_samdf,
         ch_loci_params,

--- a/main.nf
+++ b/main.nf
@@ -359,7 +359,8 @@ workflow FREYR {
     TAXONOMY (
         DADA2.out.ch_seqtab,
         ch_loci_params,
-        ch_idtaxa_db_new
+        ch_idtaxa_db_new,
+        DADA2.out.ch_seqtab_new
         )
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -30,6 +30,8 @@ params {
     dada_band_size              = 16                                // set BAND_SIZE parameter for dada2::dada function in 'denoise.R'; integer
     dada_homopolymer            = null                              // set HOMOPOLYMER_GAP_PENALTY parameter for dada2::dada function in 'denoise.R'; integer < 0
 
+    chunk_taxassign             = 100                               // number of sequences to be taxonomically assigned per process; integer > 0
+
     ///// loci_params override options
     lp_max_primer_mismatch      = null
     lp_read_min_length          = null 

--- a/nextflow.config
+++ b/nextflow.config
@@ -32,6 +32,8 @@ params {
 
     chunk_taxassign             = 100                               // number of sequences to be taxonomically assigned per process; integer > 0
 
+    accumulation_curve          = true                              // generate accumulation curves per sample for each primer pair; boolean
+
     ///// loci_params override options
     lp_max_primer_mismatch      = null
     lp_read_min_length          = null 
@@ -161,15 +163,15 @@ profiles {
         shifter.enabled             = true
     }
     test { /// this profile should always be specified last to force the minimal resource requirements
-        params.samplesheet      = 'test_data/dual/samplesheet_read_dir.csv'
-        params.loci_params      = "test_data/dual/loci_params.csv"
-        params.miseq_dir        = "test_data/dual"
-        params.max_memory       = '2.GB'
-        params.max_time         = '10.m'
-        params.max_cpus         = 1
-        params.miseq_internal   = true
-        params.seq_type         = "illumina"
-        params.paired           = true
+        params.samplesheet          = 'test_data/dual/samplesheet_read_dir.csv'
+        params.loci_params          = "test_data/dual/loci_params.csv"
+        params.miseq_dir            = "test_data/dual"
+        params.max_memory           = '2.GB'
+        params.max_time             = '10.m'
+        params.max_cpus             = 1
+        params.miseq_internal       = true
+        params.seq_type             = "illumina"
+        params.paired               = true
     }
     quick {
         params.max_time         = '10.m'

--- a/nextflow.config
+++ b/nextflow.config
@@ -238,26 +238,26 @@ plugins {
 report {
     enabled             = true
     overwrite           = true
-    file                = "output/report.html"
+    file                = "output/run_info/report.html"
 }
 
 trace {
     enabled             = true
     overwrite           = true
-    file                = "output/trace.tsv"
+    file                = "output/run_info/trace.tsv"
 }
 
 dag {
     enabled             = true
     overwrite           = true
-    file                = "output/dag.html"
+    file                = "output/run_info/dag.html"
     verbose             = true
 }
 
 timeline {
     enabled             = true
     overwrite           = true
-    file                = "output/timeline.html"
+    file                = "output/run_info/timeline.html"
 }
 
 // Function to ensure that resource requirements don't go beyond a maximum limit

--- a/nextflow/modules/accumulation_curve.nf
+++ b/nextflow/modules/accumulation_curve.nf
@@ -1,16 +1,14 @@
-process PHYLOSEQ_UNFILTERED {
-    def module_name = "phyloseq_unfiltered"
+process ACCUMULATION_CURVE {
+    def module_name = "accumulation_curve"
     tag "$pcr_primers"
     label "phyloseq"
     container "jackscanlan/piperline-multi:0.0.1"
 
     input:
-    tuple val(pcr_primers), path(taxtab), path(seqtab_list), path(fasta_list), path(samdf_locus), val(loci_params)
+    tuple val(pcr_primers), path(ps_file), path(filters_tibble), val(loci_params)
 
     output:
-    path("*.csv"),                                                                                 emit: csvs
-    tuple val(pcr_primers), path("ps_unfiltered_*.rds"), path("filters_*.csv"), val(loci_params),  emit: ps 
-    path("*.fasta"),                                                                               emit: asv_fasta
+    path("accumulation_curve_*.pdf"),                                          emit: pdf
 
     publishDir "${projectDir}/output/modules/${module_name}", mode: 'copy'
 
@@ -24,11 +22,9 @@ process PHYLOSEQ_UNFILTERED {
     ### defining Nextflow environment variables as R variables
     ## input channel variables
     pcr_primers =           "${pcr_primers}"
-    taxtab_file =           "${taxtab}"
-    seqtab_list =           "${seqtab_list}"
-    fasta_list =            "${fasta_list}"
+    ps_file =               "${ps_file}"
     loci_params =           "${loci_params}"
-    samdf =                 "${samdf_locus}"
+    min_sample_reads =      "${loci_params.min_sample_reads}"
     
     ## global variables
     projectDir = "$projectDir"

--- a/nextflow/modules/assignment_plot.nf
+++ b/nextflow/modules/assignment_plot.nf
@@ -5,7 +5,7 @@ process ASSIGNMENT_PLOT {
     container "jackscanlan/piperline-multi:0.0.1"
 
     input:
-    tuple val(pcr_primers), val(fcid), val(loci_params), path(seqtab), path(blast), path(tax)
+    tuple val(pcr_primers), val(fcid), val(loci_params), path(fasta), path(blast), path(tax)
 
     output:
     path("*_taxonomic_assignment_summary.pdf"), emit: plot
@@ -24,7 +24,7 @@ process ASSIGNMENT_PLOT {
     ## input channel variables
     fcid =                  "${fcid}"
     pcr_primers =           "${pcr_primers}"
-    seqtab =                "${seqtab}"
+    fasta =                 "${fasta}"
     blast =                 "${blast}"
     tax =                   "${tax}"
     target_gene =           "${loci_params.target_gene}"

--- a/nextflow/modules/assignment_plot.nf
+++ b/nextflow/modules/assignment_plot.nf
@@ -5,7 +5,7 @@ process ASSIGNMENT_PLOT {
     container "jackscanlan/piperline-multi:0.0.1"
 
     input:
-    tuple val(pcr_primers), val(fcid), val(loci_params), path(fasta), path(blast), path(tax)
+    tuple val(pcr_primers), val(fcid), val(loci_params), path(fasta), path(blast, name: "blast*.rds"), path(tax)
 
     output:
     path("*_taxonomic_assignment_summary.pdf"), emit: plot
@@ -25,7 +25,7 @@ process ASSIGNMENT_PLOT {
     fcid =                  "${fcid}"
     pcr_primers =           "${pcr_primers}"
     fasta =                 "${fasta}"
-    blast =                 "${blast}"
+    blast_list =            "${blast}"
     tax =                   "${tax}"
     target_gene =           "${loci_params.target_gene}"
     idtaxa_db =             "${loci_params.idtaxa_db}"

--- a/nextflow/modules/filter_seqtab.nf
+++ b/nextflow/modules/filter_seqtab.nf
@@ -5,15 +5,11 @@ process FILTER_SEQTAB {
     container "jackscanlan/piperline-multi:0.0.1"
 
     input:
-    tuple val(pcr_primers), val(fcid), val(meta), path(seqtab)
     tuple val(pcr_primers), val(fcid), val(meta), path(seqtab_tibble), path(fasta)
 
     output:
-    tuple val(pcr_primers), val(fcid), path("*_seqtab.cleaned.rds"),                emit: seqtab
-    tuple val(pcr_primers), val(fcid), path("*_ASV_cleanup_summary.csv"),           emit: csv
-    tuple val(pcr_primers), val(fcid), path("*_ASV_cleanup_summary.pdf"),           emit: plot
-    tuple val(pcr_primers), val(fcid), path("*_seqtab_filtered.csv"), path(fasta),  emit: seqtab_new
-    tuple val(pcr_primers), val(fcid), path("*_ASV_cleanup.csv"),                   emit: csv_new
+    tuple val(pcr_primers), val(fcid), path("*_seqtab_filtered.csv"), path(fasta),  emit: seqtab
+    tuple val(pcr_primers), val(fcid), path("*_ASV_cleanup.csv"),                   emit: csv
     tuple val(pcr_primers), val(fcid), path("*_asv_abundance.pdf"),                 emit: abundance_plot
     tuple val(pcr_primers), val(fcid), path("*_asv_count.pdf"),                     emit: count_plot
     path("*_readsout.csv"),                                                         emit: read_tracking
@@ -32,7 +28,6 @@ process FILTER_SEQTAB {
     ## input channel variables
     fcid =              "${fcid}"
     pcr_primers =       "${pcr_primers}"
-    seqtab =            "${seqtab}"
     asv_min_length =    "${meta.asv_min_length}"
     asv_max_length =    "${meta.asv_max_length}"
     phmm =              "${meta.phmm}"

--- a/nextflow/modules/filter_seqtab.nf
+++ b/nextflow/modules/filter_seqtab.nf
@@ -6,11 +6,16 @@ process FILTER_SEQTAB {
 
     input:
     tuple val(pcr_primers), val(fcid), val(meta), path(seqtab)
+    tuple val(pcr_primers), val(fcid), val(meta), path(seqtab_tibble), path(fasta)
 
     output:
     tuple val(pcr_primers), val(fcid), path("*_seqtab.cleaned.rds"),         emit: seqtab
     tuple val(pcr_primers), val(fcid), path("*_ASV_cleanup_summary.csv"),    emit: csv
     tuple val(pcr_primers), val(fcid), path("*_ASV_cleanup_summary.pdf"),    emit: plot
+    tuple val(pcr_primers), val(fcid), path("*_seqtab_filtered.csv"),        emit: seqtab_new
+    tuple val(pcr_primers), val(fcid), path("*_ASV_cleanup.csv"),            emit: csv_new
+    tuple val(pcr_primers), val(fcid), path("*_asv_abundance.pdf"),          emit: abundance_plot
+    tuple val(pcr_primers), val(fcid), path("*_asv_count.pdf"),              emit: count_plot
     path("*_readsout.csv"),                                                  emit: read_tracking
 
 
@@ -22,7 +27,7 @@ process FILTER_SEQTAB {
     def module_script = "${module_name}.R"
     """
     #!/usr/bin/env Rscript
-
+        
     ### defining Nextflow environment variables as R variables
     ## input channel variables
     fcid =              "${fcid}"
@@ -35,6 +40,8 @@ process FILTER_SEQTAB {
     genetic_code =      "${meta.genetic_code}"
     for_primer_seq =    "${meta.for_primer_seq}"
     rev_primer_seq =    "${meta.rev_primer_seq}"
+    seqtab_tibble =     "${seqtab_tibble}"
+    fasta =             "${fasta}"
 
     
     ## global variables

--- a/nextflow/modules/filter_seqtab.nf
+++ b/nextflow/modules/filter_seqtab.nf
@@ -9,14 +9,14 @@ process FILTER_SEQTAB {
     tuple val(pcr_primers), val(fcid), val(meta), path(seqtab_tibble), path(fasta)
 
     output:
-    tuple val(pcr_primers), val(fcid), path("*_seqtab.cleaned.rds"),         emit: seqtab
-    tuple val(pcr_primers), val(fcid), path("*_ASV_cleanup_summary.csv"),    emit: csv
-    tuple val(pcr_primers), val(fcid), path("*_ASV_cleanup_summary.pdf"),    emit: plot
-    tuple val(pcr_primers), val(fcid), path("*_seqtab_filtered.csv"),        emit: seqtab_new
-    tuple val(pcr_primers), val(fcid), path("*_ASV_cleanup.csv"),            emit: csv_new
-    tuple val(pcr_primers), val(fcid), path("*_asv_abundance.pdf"),          emit: abundance_plot
-    tuple val(pcr_primers), val(fcid), path("*_asv_count.pdf"),              emit: count_plot
-    path("*_readsout.csv"),                                                  emit: read_tracking
+    tuple val(pcr_primers), val(fcid), path("*_seqtab.cleaned.rds"),                emit: seqtab
+    tuple val(pcr_primers), val(fcid), path("*_ASV_cleanup_summary.csv"),           emit: csv
+    tuple val(pcr_primers), val(fcid), path("*_ASV_cleanup_summary.pdf"),           emit: plot
+    tuple val(pcr_primers), val(fcid), path("*_seqtab_filtered.csv"), path(fasta),  emit: seqtab_new
+    tuple val(pcr_primers), val(fcid), path("*_ASV_cleanup.csv"),                   emit: csv_new
+    tuple val(pcr_primers), val(fcid), path("*_asv_abundance.pdf"),                 emit: abundance_plot
+    tuple val(pcr_primers), val(fcid), path("*_asv_count.pdf"),                     emit: count_plot
+    path("*_readsout.csv"),                                                         emit: read_tracking
 
 
     publishDir "${projectDir}/output/modules/${module_name}", mode: 'copy'

--- a/nextflow/modules/joint_tax.nf
+++ b/nextflow/modules/joint_tax.nf
@@ -5,7 +5,7 @@ process JOINT_TAX {
     container "jackscanlan/piperline-multi:0.0.1"
 
     input:
-    tuple val(pcr_primers), val(fcid), val(loci_params), path(tax), path(blast)
+    tuple val(pcr_primers), val(fcid), val(loci_params), path(tax, name: "idtaxa*.csv"), path(blast, name: "blast*.csv")
     
     output:
     tuple val(pcr_primers), val(fcid), path("*_joint.csv"), emit: joint
@@ -18,14 +18,14 @@ process JOINT_TAX {
     def module_script = "${module_name}.R"
     """
     #!/usr/bin/env Rscript
-
+    
     ### defining Nextflow environment variables as R variables
     ## input channel variables
     fcid =                  "${fcid}"
     pcr_primers =           "${pcr_primers}"
     target_gene =           "${loci_params.target_gene}"
-    idtaxa_output =         "${tax}"
-    blast_output =          "${blast}"
+    idtaxa_list =           "${tax}"
+    blast_list =            "${blast}"
     
     ## global variables
     projectDir = "$projectDir"

--- a/nextflow/modules/joint_tax.nf
+++ b/nextflow/modules/joint_tax.nf
@@ -5,7 +5,7 @@ process JOINT_TAX {
     container "jackscanlan/piperline-multi:0.0.1"
 
     input:
-    tuple val(pcr_primers), val(fcid), val(loci_params), path(tax), path(blast), path(seqtab_tibble)
+    tuple val(pcr_primers), val(fcid), val(loci_params), path(tax), path(blast)
     
     output:
     tuple val(pcr_primers), val(fcid), path("*_joint.csv"), emit: joint
@@ -26,7 +26,6 @@ process JOINT_TAX {
     target_gene =           "${loci_params.target_gene}"
     idtaxa_output =         "${tax}"
     blast_output =          "${blast}"
-    seqtab_tibble =         "${seqtab_tibble}"
     
     ## global variables
     projectDir = "$projectDir"

--- a/nextflow/modules/joint_tax.nf
+++ b/nextflow/modules/joint_tax.nf
@@ -5,10 +5,10 @@ process JOINT_TAX {
     container "jackscanlan/piperline-multi:0.0.1"
 
     input:
-    tuple val(pcr_primers), val(fcid), val(loci_params), path(tax), path(blast), path(seqtab)
+    tuple val(pcr_primers), val(fcid), val(loci_params), path(tax), path(blast), path(seqtab_tibble)
     
     output:
-    tuple val(pcr_primers), val(fcid), path("*_taxblast.rds"), emit: taxtab
+    tuple val(pcr_primers), val(fcid), path("*_joint.csv"), emit: joint
 
     publishDir "${projectDir}/output/modules/${module_name}", mode: 'copy'
 
@@ -26,7 +26,7 @@ process JOINT_TAX {
     target_gene =           "${loci_params.target_gene}"
     idtaxa_output =         "${tax}"
     blast_output =          "${blast}"
-    seqtab =                "${seqtab}"
+    seqtab_tibble =         "${seqtab_tibble}"
     
     ## global variables
     projectDir = "$projectDir"

--- a/nextflow/modules/make_seqtab_paired.nf
+++ b/nextflow/modules/make_seqtab_paired.nf
@@ -8,8 +8,9 @@ process MAKE_SEQTAB_PAIRED {
     tuple val(pcr_primers), val(fcid), val(concat_unmerged), val(meta), path(readsF), path(readsR), path(seqsF), path(seqsR)
 
     output:
-    tuple val(pcr_primers), val(fcid), val(meta), path("*_seqtab.rds"), emit: seqtab
-    path("*_readsout.csv"),                                             emit: read_tracking
+    tuple val(pcr_primers), val(fcid), val(meta), path("*_seqtab.rds"),                                 emit: seqtab
+    tuple val(pcr_primers), val(fcid), val(meta), path("*_seqtab_tibble.csv"), path("*_seqs.fasta"),    emit: seqtab_new
+    path("*_readsout.csv"),                                                                             emit: read_tracking
 
     publishDir "${projectDir}/output/modules/${module_name}", mode: 'copy'
 

--- a/nextflow/modules/make_seqtab_paired.nf
+++ b/nextflow/modules/make_seqtab_paired.nf
@@ -8,8 +8,7 @@ process MAKE_SEQTAB_PAIRED {
     tuple val(pcr_primers), val(fcid), val(concat_unmerged), val(meta), path(readsF), path(readsR), path(seqsF), path(seqsR)
 
     output:
-    tuple val(pcr_primers), val(fcid), val(meta), path("*_seqtab.rds"),                                 emit: seqtab
-    tuple val(pcr_primers), val(fcid), val(meta), path("*_seqtab_tibble.csv"), path("*_seqs.fasta"),    emit: seqtab_new
+    tuple val(pcr_primers), val(fcid), val(meta), path("*_seqtab_tibble.csv"), path("*_seqs.fasta"),    emit: seqtab
     path("*_readsout.csv"),                                                                             emit: read_tracking
 
     publishDir "${projectDir}/output/modules/${module_name}", mode: 'copy'

--- a/nextflow/modules/make_seqtab_single.nf
+++ b/nextflow/modules/make_seqtab_single.nf
@@ -8,8 +8,9 @@ process MAKE_SEQTAB_SINGLE {
     tuple val(pcr_primers), val(fcid), val(concat_unmerged), val(meta), path(reads), path(seqs)
 
     output:
-    tuple val(pcr_primers), val(fcid), val(meta), path("*_seqtab.rds"), emit: seqtab
-    path("*_readsout.csv"),                                             emit: read_tracking
+    tuple val(pcr_primers), val(fcid), val(meta), path("*_seqtab.rds"),                                 emit: seqtab
+    tuple val(pcr_primers), val(fcid), val(meta), path("*_seqtab_tibble.csv"), path("*_seqs.fasta"),    emit: seqtab_new
+    path("*_readsout.csv"),                                                                             emit: read_tracking
 
     publishDir "${projectDir}/output/modules/${module_name}", mode: 'copy'
 

--- a/nextflow/modules/make_seqtab_single.nf
+++ b/nextflow/modules/make_seqtab_single.nf
@@ -8,8 +8,7 @@ process MAKE_SEQTAB_SINGLE {
     tuple val(pcr_primers), val(fcid), val(concat_unmerged), val(meta), path(reads), path(seqs)
 
     output:
-    tuple val(pcr_primers), val(fcid), val(meta), path("*_seqtab.rds"),                                 emit: seqtab
-    tuple val(pcr_primers), val(fcid), val(meta), path("*_seqtab_tibble.csv"), path("*_seqs.fasta"),    emit: seqtab_new
+    tuple val(pcr_primers), val(fcid), val(meta), path("*_seqtab_tibble.csv"), path("*_seqs.fasta"),    emit: seqtab
     path("*_readsout.csv"),                                                                             emit: read_tracking
 
     publishDir "${projectDir}/output/modules/${module_name}", mode: 'copy'

--- a/nextflow/modules/merge_tax.nf
+++ b/nextflow/modules/merge_tax.nf
@@ -5,10 +5,10 @@ process MERGE_TAX {
     container "jackscanlan/piperline-multi:0.0.1"
 
     input:
-    tuple val(pcr_primers), val(fcid), path(taxtab)
+    tuple val(pcr_primers), path(taxtabs)
 
     output:
-    tuple val(pcr_primers), path("*_merged_tax.rds"), emit: merged_tax
+    tuple val(pcr_primers), path("*_merged_tax.csv"), emit: merged_tax
 
     publishDir "${projectDir}/output/modules/${module_name}", mode: 'copy'
 
@@ -22,8 +22,7 @@ process MERGE_TAX {
     ### defining Nextflow environment variables as R variables
     ## input channel variables
     pcr_primers =           "${pcr_primers}"
-    fcid =                  "${fcid}"
-    taxtab =                "${taxtab}"
+    taxtabs =                "${taxtabs}"
     
     ## global variables
     projectDir = "$projectDir"

--- a/nextflow/modules/phyloseq_filter.nf
+++ b/nextflow/modules/phyloseq_filter.nf
@@ -5,14 +5,12 @@ process PHYLOSEQ_FILTER {
     container "jackscanlan/piperline-multi:0.0.1"
 
     input:
-    tuple val(pcr_primers), path(ps), val(loci_params)
+    tuple val(pcr_primers), path(ps), path(filters_tibble), val(loci_params)
 
     output:
     path("*.csv"),                                                          emit: csvs
     tuple val(pcr_primers), path("ps_filtered_*.rds"), val(loci_params),    emit: ps 
     path("*.fasta"),                                                        emit: asv_fasta
-    path("*.nwk"),                                                          emit: nwk, optional: true
-
 
     publishDir "${projectDir}/output/modules/${module_name}", mode: 'copy'
 
@@ -27,6 +25,7 @@ process PHYLOSEQ_FILTER {
     ## input channel variables
     pcr_primers =           "${pcr_primers}"
     ps =                    "${ps}"
+    filters_tibble =        "${filters_tibble}"
     target_kingdom =        "${loci_params.target_kingdom}"
     target_phylum =         "${loci_params.target_phylum}"
     target_class =          "${loci_params.target_class}"

--- a/nextflow/modules/phyloseq_merge.nf
+++ b/nextflow/modules/phyloseq_merge.nf
@@ -7,6 +7,8 @@ process PHYLOSEQ_MERGE {
     input:
     path(ps_unfiltered)
     path(ps_filtered)
+    path(unfiltered_fastas, name: "unfiltered_*.fasta")
+    path(filtered_fastas, name: "filtered_*.fasta")
 
     output:
     path("*.csv")
@@ -28,6 +30,8 @@ process PHYLOSEQ_MERGE {
     ## input channel variables
     ps_unfiltered =                  "${ps_unfiltered}"
     ps_filtered =                    "${ps_filtered}"
+    unfiltered_fastas =              "${unfiltered_fastas}"
+    filtered_fastas =                "${filtered_fastas}"
     
     ## global variables
     projectDir = "$projectDir"

--- a/nextflow/modules/phyloseq_unfiltered.nf
+++ b/nextflow/modules/phyloseq_unfiltered.nf
@@ -5,14 +5,13 @@ process PHYLOSEQ_UNFILTERED {
     container "jackscanlan/piperline-multi:0.0.1"
 
     input:
-    tuple val(pcr_primers), path(taxtab), path(seqtab_list), path(samdf_locus), val(loci_params)
+    tuple val(pcr_primers), path(taxtab), path(seqtab_list), path(fasta_list), path(samdf_locus), val(loci_params)
 
     output:
     path("*.csv"),                                                          emit: csvs
     tuple val(pcr_primers), path("ps_unfiltered_*.rds"), val(loci_params),  emit: ps 
     path("*.fasta"),                                                        emit: asv_fasta
     // path("accumulation_curve_*.pdf"),                                       emit: acc_curve
-    path("*.nwk"),                                                          emit: nwk, optional: true
 
     publishDir "${projectDir}/output/modules/${module_name}", mode: 'copy'
 
@@ -26,8 +25,9 @@ process PHYLOSEQ_UNFILTERED {
     ### defining Nextflow environment variables as R variables
     ## input channel variables
     pcr_primers =           "${pcr_primers}"
-    taxtab =                "${taxtab}"
+    taxtab_file =           "${taxtab}"
     seqtab_list =           "${seqtab_list}"
+    fasta_list =            "${fasta_list}"
     loci_params =           "${loci_params}"
     samdf =                 "${samdf_locus}"
     

--- a/nextflow/modules/phyloseq_unfiltered.nf
+++ b/nextflow/modules/phyloseq_unfiltered.nf
@@ -29,7 +29,7 @@ process PHYLOSEQ_UNFILTERED {
     fasta_list =            "${fasta_list}"
     loci_params =           "${loci_params}"
     samdf =                 "${samdf_locus}"
-    
+     
     ## global variables
     projectDir = "$projectDir"
     params_dict = "$params"

--- a/nextflow/modules/phyloseq_unfiltered.nf
+++ b/nextflow/modules/phyloseq_unfiltered.nf
@@ -8,9 +8,9 @@ process PHYLOSEQ_UNFILTERED {
     tuple val(pcr_primers), path(taxtab), path(seqtab_list), path(fasta_list), path(samdf_locus), val(loci_params)
 
     output:
-    path("*.csv"),                                                          emit: csvs
-    tuple val(pcr_primers), path("ps_unfiltered_*.rds"), val(loci_params),  emit: ps 
-    path("*.fasta"),                                                        emit: asv_fasta
+    path("*.csv"),                                                                                 emit: csvs
+    tuple val(pcr_primers), path("ps_unfiltered_*.rds"), path("filters_*.csv"), val(loci_params),  emit: ps 
+    path("*.fasta"),                                                                               emit: asv_fasta
     // path("accumulation_curve_*.pdf"),                                       emit: acc_curve
 
     publishDir "${projectDir}/output/modules/${module_name}", mode: 'copy'

--- a/nextflow/modules/tax_blast.nf
+++ b/nextflow/modules/tax_blast.nf
@@ -8,7 +8,7 @@ process TAX_BLAST {
     tuple val(pcr_primers), val(fcid), val(loci_params), path(fasta)
 
     output:
-    tuple val(pcr_primers), val(fcid), val(loci_params), path("*_blast.rds"),   emit: blast
+    tuple val(pcr_primers), val(fcid), val(loci_params), path("*_blast.csv"),   emit: blast
     tuple val(pcr_primers), val(fcid), path("*_blast_spp_low.rds"),             emit: blast_assignment
     tuple val(pcr_primers), val(fcid), path("*_n_ranks.txt"),                   emit: n_ranks
 

--- a/nextflow/modules/tax_blast.nf
+++ b/nextflow/modules/tax_blast.nf
@@ -5,12 +5,12 @@ process TAX_BLAST {
     container "jackscanlan/piperline-multi:0.0.1"
 
     input:
-    tuple val(pcr_primers), val(fcid), val(loci_params), path(seqtab)
+    tuple val(pcr_primers), val(fcid), val(loci_params), path(fasta)
 
     output:
-    tuple val(pcr_primers), val(fcid), val(loci_params), path("*_blast.rds"), emit: blast
-    tuple val(pcr_primers), val(fcid), path("*_blast_spp_low.rds"), emit: blast_assignment
-    tuple val(pcr_primers), val(fcid), path("*_n_ranks.txt"), emit: n_ranks
+    tuple val(pcr_primers), val(fcid), val(loci_params), path("*_blast.rds"),   emit: blast
+    tuple val(pcr_primers), val(fcid), path("*_blast_spp_low.rds"),             emit: blast_assignment
+    tuple val(pcr_primers), val(fcid), path("*_n_ranks.txt"),                   emit: n_ranks
 
     publishDir "${projectDir}/output/modules/${module_name}", mode: 'copy'
 
@@ -25,7 +25,7 @@ process TAX_BLAST {
     ## input channel variables
     fcid =                  "${fcid}"
     pcr_primers =           "${pcr_primers}"
-    seqtab =                "${seqtab}"
+    fasta =                 "${fasta}"
     target_gene =           "${loci_params.target_gene}"
     ref_fasta =             "${loci_params.ref_fasta}"
     blast_min_identity =    "${loci_params.blast_min_identity}"

--- a/nextflow/modules/tax_idtaxa.nf
+++ b/nextflow/modules/tax_idtaxa.nf
@@ -5,7 +5,8 @@ process TAX_IDTAXA {
     container "jackscanlan/piperline-multi:0.0.1"
 
     input:
-    tuple val(pcr_primers), val(fcid), val(loci_params), path(seqtab)
+    tuple val(pcr_primers), val(fcid), val(loci_params), path(fasta)
+    //tuple val(pcr_primers2), val(fcid2), val(loci_params2), path(fasta)
 
     output:
     tuple val(pcr_primers), val(fcid), val(loci_params), path("*_idtaxa_tax.rds"), emit: tax
@@ -24,9 +25,9 @@ process TAX_IDTAXA {
     ## input channel variables
     fcid =              "${fcid}"
     pcr_primers =       "${pcr_primers}"
-    seqtab =            "${seqtab}"
     idtaxa_confidence = "${loci_params.idtaxa_confidence}"
     idtaxa_db =         "${loci_params.idtaxa_db}"
+    fasta =             "${fasta}"
 
     ## global variables
     projectDir = "$projectDir"

--- a/nextflow/modules/tax_idtaxa.nf
+++ b/nextflow/modules/tax_idtaxa.nf
@@ -6,7 +6,6 @@ process TAX_IDTAXA {
 
     input:
     tuple val(pcr_primers), val(fcid), val(loci_params), path(fasta)
-    //tuple val(pcr_primers2), val(fcid2), val(loci_params2), path(fasta)
 
     output:
     tuple val(pcr_primers), val(fcid), val(loci_params), path("*_idtaxa_tax.csv"), emit: tax

--- a/nextflow/modules/tax_idtaxa.nf
+++ b/nextflow/modules/tax_idtaxa.nf
@@ -9,7 +9,7 @@ process TAX_IDTAXA {
     //tuple val(pcr_primers2), val(fcid2), val(loci_params2), path(fasta)
 
     output:
-    tuple val(pcr_primers), val(fcid), val(loci_params), path("*_idtaxa_tax.rds"), emit: tax
+    tuple val(pcr_primers), val(fcid), val(loci_params), path("*_idtaxa_tax.csv"), emit: tax
     tuple val(pcr_primers), val(fcid), val(loci_params), path("*_idtaxa_ids.rds"), emit: ids
 
     publishDir "${projectDir}/output/modules/${module_name}", mode: 'copy'

--- a/nextflow/modules/tax_summary.nf
+++ b/nextflow/modules/tax_summary.nf
@@ -24,13 +24,13 @@ process TAX_SUMMARY {
     ## input channel variables
     pcr_primers =           "${pcr_primers}"
     fcid =                  "${fcid}"   
-    tax =                   "${tax}"
-    ids =                   "${ids}"
+    tax_file =              "${tax}"
+    ids_file =              "${ids}"
     joint_file =            "${joint}"
     target_gene =           "${loci_params.target_gene}"
     idtaxa_db =             "${loci_params.idtaxa_db}"
     ref_fasta =             "${loci_params.ref_fasta}"
-    
+      
     ## global variables
     projectDir = "$projectDir"
     params_dict = "$params"

--- a/nextflow/modules/tax_summary.nf
+++ b/nextflow/modules/tax_summary.nf
@@ -5,7 +5,7 @@ process TAX_SUMMARY {
     container "jackscanlan/piperline-multi:0.0.1"
 
     input:
-    tuple val(pcr_primers), val(fcid), val(loci_params), path(tax), path(ids), path(joint)
+    tuple val(pcr_primers), val(fcid), val(loci_params), path(fasta), path(tax, name: "idtaxa*.csv"), path(ids, name: "idtaxa*.rds"), path(joint)
 
     output:
     tuple val(pcr_primers), val(fcid), val(loci_params), path("*_taxonomic_assignment_summary.rds"), emit: rds
@@ -24,8 +24,9 @@ process TAX_SUMMARY {
     ## input channel variables
     pcr_primers =           "${pcr_primers}"
     fcid =                  "${fcid}"   
-    tax_file =              "${tax}"
-    ids_file =              "${ids}"
+    fasta =                 "${fasta}"
+    tax_list =              "${tax}"
+    ids_list =              "${ids}"
     joint_file =            "${joint}"
     target_gene =           "${loci_params.target_gene}"
     idtaxa_db =             "${loci_params.idtaxa_db}"

--- a/nextflow/modules/tax_summary.nf
+++ b/nextflow/modules/tax_summary.nf
@@ -9,7 +9,7 @@ process TAX_SUMMARY {
 
     output:
     tuple val(pcr_primers), val(fcid), val(loci_params), path("*_taxonomic_assignment_summary.rds"), emit: rds
-    path("*_taxonomic_assignment_summary.csv"), emit: csv
+    tuple val(pcr_primers), val(fcid), val(loci_params), path("*_taxonomic_assignment_summary.csv"), emit: csv
 
     publishDir "${projectDir}/output/modules/${module_name}", mode: 'copy'
 

--- a/nextflow/subworkflows/dada2.nf
+++ b/nextflow/subworkflows/dada2.nf
@@ -211,8 +211,7 @@ workflow DADA2 {
 
         //// filter sequence table
         FILTER_SEQTAB ( 
-            MAKE_SEQTAB_PAIRED.out.seqtab,
-            MAKE_SEQTAB_PAIRED.out.seqtab_new
+            MAKE_SEQTAB_PAIRED.out.seqtab
         )
 
 
@@ -292,8 +291,7 @@ workflow DADA2 {
 
         //// filter sequence table
         FILTER_SEQTAB ( 
-            MAKE_SEQTAB_SINGLE.out.seqtab,
-            MAKE_SEQTAB_SINGLE.out.seqtab_new
+            MAKE_SEQTAB_SINGLE.out.seqtab
         )
 
 
@@ -307,15 +305,11 @@ workflow DADA2 {
     ch_seqtab = 
         FILTER_SEQTAB.out.seqtab
 
-    ch_seqtab_new = 
-        FILTER_SEQTAB.out.seqtab_new
-
 
     emit:
 
     ch_seqtab
     read_tracker_grouped
-    ch_seqtab_new
 
 
 }

--- a/nextflow/subworkflows/dada2.nf
+++ b/nextflow/subworkflows/dada2.nf
@@ -215,14 +215,6 @@ workflow DADA2 {
             MAKE_SEQTAB_PAIRED.out.seqtab_new
         )
 
-        read_tracker_grouped = 
-            read_tracker_grouped.concat(FILTER_SEQTAB.out.read_tracking)
-
-        ch_seqtab = 
-            FILTER_SEQTAB.out.seqtab
-
-
-
 
     } else if ( params.paired == false && params.seq_type == "nanopore" )  {
 
@@ -304,23 +296,26 @@ workflow DADA2 {
             MAKE_SEQTAB_SINGLE.out.seqtab_new
         )
 
-        read_tracker_grouped = 
-            read_tracker_grouped.concat(FILTER_SEQTAB.out.read_tracking)
-
-        ch_seqtab = 
-            FILTER_SEQTAB.out.seqtab
-            
-
 
     } else {
         error ("Disallowed 'params.paired' and 'params.seq_type' combination")
     }
+
+    read_tracker_grouped = 
+        read_tracker_grouped.concat(FILTER_SEQTAB.out.read_tracking)
+
+    ch_seqtab = 
+        FILTER_SEQTAB.out.seqtab
+
+    ch_seqtab_new = 
+        FILTER_SEQTAB.out.seqtab_new
 
 
     emit:
 
     ch_seqtab
     read_tracker_grouped
+    ch_seqtab_new
 
 
 }

--- a/nextflow/subworkflows/dada2.nf
+++ b/nextflow/subworkflows/dada2.nf
@@ -202,13 +202,18 @@ workflow DADA2 {
         }
 
         //// merge paired-end reads per flowcell x locus combo
-        MAKE_SEQTAB_PAIRED ( ch_seq_combined )
+        MAKE_SEQTAB_PAIRED ( 
+            ch_seq_combined 
+        )
 
         read_tracker_grouped = 
             read_tracker_grouped.concat(MAKE_SEQTAB_PAIRED.out.read_tracking)
 
         //// filter sequence table
-        FILTER_SEQTAB ( MAKE_SEQTAB_PAIRED.out.seqtab )
+        FILTER_SEQTAB ( 
+            MAKE_SEQTAB_PAIRED.out.seqtab,
+            MAKE_SEQTAB_PAIRED.out.seqtab_new
+        )
 
         read_tracker_grouped = 
             read_tracker_grouped.concat(FILTER_SEQTAB.out.read_tracking)
@@ -286,13 +291,18 @@ workflow DADA2 {
         }
 
         //// merge paired-end reads per flowcell x locus combo
-        MAKE_SEQTAB_SINGLE ( ch_seq_single )
+        MAKE_SEQTAB_SINGLE ( 
+            ch_seq_single 
+        )
 
         read_tracker_grouped = 
             read_tracker_grouped.concat(MAKE_SEQTAB_SINGLE.out.read_tracking)
 
         //// filter sequence table
-        FILTER_SEQTAB ( MAKE_SEQTAB_SINGLE.out.seqtab )
+        FILTER_SEQTAB ( 
+            MAKE_SEQTAB_SINGLE.out.seqtab,
+            MAKE_SEQTAB_SINGLE.out.seqtab_new
+        )
 
         read_tracker_grouped = 
             read_tracker_grouped.concat(FILTER_SEQTAB.out.read_tracking)

--- a/nextflow/subworkflows/result_summaries.nf
+++ b/nextflow/subworkflows/result_summaries.nf
@@ -45,7 +45,7 @@ workflow RESULT_SUMMARIES {
 
     //// combine phyloseq outputs to merge across loci
     PHYLOSEQ_UNFILTERED.out.ps // val(pcr_primers), path("ps_unfiltered_*.rds"), val(loci_params)
-        .map { pcr_primers, ps, loci_params ->
+        .map { pcr_primers, ps, filters_tibble, loci_params ->
             [ ps ] }
         .collect()
         .set { ch_ps_unfiltered }

--- a/nextflow/subworkflows/result_summaries.nf
+++ b/nextflow/subworkflows/result_summaries.nf
@@ -58,7 +58,9 @@ workflow RESULT_SUMMARIES {
 
     PHYLOSEQ_MERGE ( 
         ch_ps_unfiltered, 
-        ch_ps_filtered 
+        ch_ps_filtered,
+        PHYLOSEQ_UNFILTERED.out.asv_fasta.collect(),
+        PHYLOSEQ_FILTER.out.asv_fasta.collect()
         )
     
     ch_read_tracker_grouped = 

--- a/nextflow/subworkflows/result_summaries.nf
+++ b/nextflow/subworkflows/result_summaries.nf
@@ -4,6 +4,7 @@
 
 
 //// modules to import
+include { ACCUMULATION_CURVE                        } from '../modules/accumulation_curve'
 include { PHYLOSEQ_UNFILTERED                       } from '../modules/phyloseq_unfiltered'
 include { PHYLOSEQ_FILTER                           } from '../modules/phyloseq_filter'
 include { PHYLOSEQ_MERGE                            } from '../modules/phyloseq_merge'
@@ -39,6 +40,11 @@ workflow RESULT_SUMMARIES {
 
     //// create phyloseq objects per locus; output unfiltered summary tables and accumulation curve plot
     PHYLOSEQ_UNFILTERED ( ch_phyloseq_input )
+
+    //// create accumulation curve plots
+    ACCUMULATION_CURVE (
+        PHYLOSEQ_UNFILTERED.out.ps
+    )
 
     //// apply taxonomic and minimum abundance filtering per locus (from loci_params), then combine to output filtered summary tables
     PHYLOSEQ_FILTER ( PHYLOSEQ_UNFILTERED.out.ps )

--- a/nextflow/subworkflows/result_summaries.nf
+++ b/nextflow/subworkflows/result_summaries.nf
@@ -27,15 +27,15 @@ workflow RESULT_SUMMARIES {
     //// inputs for PHYLOSEQ_UNFILTERED
     ch_seqtables_locus = 
         ch_seqtab
-        .map { pcr_primers, fcid, seqtab -> [ pcr_primers, seqtab ] } // remove fcid and loci_params fields
-        .groupTuple ( by: 0 ) // group seqtabs into lists per locus
+        .map { pcr_primers, fcid, seqtab, fasta -> [ pcr_primers, seqtab, fasta ] } // remove fcid and loci_params fields
+        .groupTuple ( by: 0 ) // group seqtabs and fastas into lists per locus
     
-    // combine taxtables, seqtables and parameters
+    // combine taxtables, seqtables and parameters by pcr_primers
     ch_mergetax_output
         .join ( ch_seqtables_locus, by: 0 )
         .join ( ch_loci_samdf, by: 0 )
         .join ( ch_loci_params, by: 0 )
-        .set { ch_phyloseq_input }
+        .set { ch_phyloseq_input } // pcr_primers, merged_tax, list[seqtab], list[fasta], loci_samdf, map[loci_params]
 
     //// create phyloseq objects per locus; output unfiltered summary tables and accumulation curve plot
     PHYLOSEQ_UNFILTERED ( ch_phyloseq_input )

--- a/nextflow/subworkflows/taxonomy.nf
+++ b/nextflow/subworkflows/taxonomy.nf
@@ -19,6 +19,7 @@ workflow TAXONOMY {
     ch_seqtab
     ch_loci_params
     ch_idtaxa_db_new
+    ch_seqtab_new
 
 
     main:
@@ -38,9 +39,19 @@ workflow TAXONOMY {
                 [ pcr_primers, fcid, loci_params + [ idtaxa_db: new_idtaxa ], seqtab ] }
             .set { ch_seqtab_params }
     }
+
+    /// modify ch_seqtab_new as parallel input channel
+    ch_seqtab_new
+        .combine ( ch_loci_params, by: 0 )
+        .map { pcr_primers, fcid, seqtab, fasta, loci_params -> 
+            [ pcr_primers, fcid, loci_params, fasta ] }
+        .set { ch_seqtab_params_new }
     
     //// use IDTAXA to assign taxonomy
-    TAX_IDTAXA ( ch_seqtab_params )
+    TAX_IDTAXA ( 
+        // ch_seqtab_params,
+        ch_seqtab_params_new
+    )
     
     ch_tax_idtaxa_tax = 
         TAX_IDTAXA.out.tax

--- a/nextflow/subworkflows/taxonomy.nf
+++ b/nextflow/subworkflows/taxonomy.nf
@@ -55,9 +55,7 @@ workflow TAXONOMY {
     
     ch_tax_idtaxa_tax = TAX_IDTAXA.out.tax
 
-
     ch_tax_idtaxa_ids = TAX_IDTAXA.out.ids 
-
 
     //// use blastn to assign taxonomy
     TAX_BLAST ( 
@@ -78,7 +76,7 @@ workflow TAXONOMY {
     JOINT_TAX ( ch_joint_tax_input )
 
     //// group taxtab across flowcells (per locus)
-    JOINT_TAX.out.taxtab
+    JOINT_TAX.out.joint
         .groupTuple ( by: 0 ) // group into tuples using pcr_primers
         .set { ch_mergetax_input }
 
@@ -91,7 +89,7 @@ workflow TAXONOMY {
     /// channel has one item per fcid x pcr_primer combo
     ch_seqtab_params // pcr_primers, fcid, loci_params, seqtab
         .join ( TAX_BLAST.out.blast_assignment, by: [0,1] ) // combine by pcr_primers, fcid 
-        .join ( JOINT_TAX.out.taxtab, by: [0,1] ) // combine by pcr_primers, fcid
+        .join ( JOINT_TAX.out.joint, by: [0,1] ) // combine by pcr_primers, fcid
         .set { ch_assignment_plot_input }
 
     //// do assignment plot

--- a/nextflow/subworkflows/taxonomy.nf
+++ b/nextflow/subworkflows/taxonomy.nf
@@ -116,14 +116,16 @@ workflow TAXONOMY {
     )
 
     // create channel containing a single list of all TAX_SUMMARY outputs
-    TAX_SUMMARY.out.rds
+    TAX_SUMMARY.out.csv
         .map { pcr_primers, fcid, loci_params, tax_summary ->
             [ tax_summary ] } 
         .collect()
         .set { ch_tax_summaries } 
 
     //// merge TAX_SUMMARY outputs together across loci and flow cells
-    TAX_SUMMARY_MERGE ( ch_tax_summaries )
+    TAX_SUMMARY_MERGE ( 
+        ch_tax_summaries 
+    )
 
 
     emit:

--- a/nextflow/subworkflows/taxonomy.nf
+++ b/nextflow/subworkflows/taxonomy.nf
@@ -53,23 +53,20 @@ workflow TAXONOMY {
         ch_seqtab_params_new
     )
     
-    ch_tax_idtaxa_tax = 
-        TAX_IDTAXA.out.tax
-        // .map { pcr_primers, fcid, meta, tax -> // remove meta
-        //     [ pcr_primers, fcid, tax ] }
+    ch_tax_idtaxa_tax = TAX_IDTAXA.out.tax
 
-    ch_tax_idtaxa_ids = 
-        TAX_IDTAXA.out.ids 
-        // .map { pcr_primers, fcid, meta, ids -> // remove meta
-        //     [ pcr_primers, fcid, ids ] }
+
+    ch_tax_idtaxa_ids = TAX_IDTAXA.out.ids 
+
 
     //// use blastn to assign taxonomy
-    TAX_BLAST ( ch_seqtab_params )
+    TAX_BLAST ( 
+        // ch_seqtab_params,
+        ch_seqtab_params_new
+    )
 
     ch_tax_blast = 
         TAX_BLAST.out.blast
-        // .map { pcr_primers, fcid, meta, blast -> // remove meta
-        //     [ pcr_primers, fcid, blast ] }
 
     //// merge tax assignment outputs and filtered seqtab (pre-assignment)
     ch_tax_idtaxa_tax // pcr_primers, fcid, loci_params, tax

--- a/nextflow/subworkflows/taxonomy.nf
+++ b/nextflow/subworkflows/taxonomy.nf
@@ -77,6 +77,7 @@ workflow TAXONOMY {
 
     //// group taxtab across flowcells (per locus)
     JOINT_TAX.out.joint
+        .map { pcr_primers, fcid, tax_tibble -> [ pcr_primers, tax_tibble ] }
         .groupTuple ( by: 0 ) // group into tuples using pcr_primers
         .set { ch_mergetax_input }
 

--- a/nextflow/subworkflows/taxonomy.nf
+++ b/nextflow/subworkflows/taxonomy.nf
@@ -86,9 +86,9 @@ workflow TAXONOMY {
 
     ch_mergetax_output = MERGE_TAX.out.merged_tax
 
-    //// create assignment_plot input merging filtered seqtab, taxtab, and blast output
+    //// create assignment_plot input merging filtered fasta, taxtab, and blast output
     /// channel has one item per fcid x pcr_primer combo
-    ch_seqtab_params // pcr_primers, fcid, loci_params, seqtab
+    ch_seqtab_params_new // pcr_primers, fcid, loci_params, fasta
         .join ( TAX_BLAST.out.blast_assignment, by: [0,1] ) // combine by pcr_primers, fcid 
         .join ( JOINT_TAX.out.joint, by: [0,1] ) // combine by pcr_primers, fcid
         .set { ch_assignment_plot_input }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -114,6 +114,13 @@
                     "help_text": "Number of sequences to taxonomically assign per process. Decreasing this may speed up the pipeline when many CPUs are available. Setting to very low values (<10) is not recommended.",
                     "default": 100
                 },
+                "accumulation_curve": {
+                    "type": "boolean",
+                    "description": "Generate accumulation curves for each sample per PCR primer pair.",
+                    "errorMessage": "Must be set to 'true' or 'false'.",
+                    "help_text": "Generate accumulation curves for each sample per PCR primer pair. On large datasets, this can take a long time.",
+                    "default": true
+                },
                 "slurm_account": {
                     "type": "string",
                     "description": "Account to use when submitting SLURM jobs.",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -110,7 +110,7 @@
                     "type": "integer",
                     "minimum": 1,
                     "description": "Number of sequences to taxonomically assign per process.",
-                    "errorMessage": "Must be an integer >= 1.",
+                    "errorMessage": "Must be an integer >= 1, preferably >10.",
                     "help_text": "Number of sequences to taxonomically assign per process. Decreasing this may speed up the pipeline when many CPUs are available. Setting to very low values (<10) is not recommended.",
                     "default": 100
                 },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -106,6 +106,14 @@
                     "errorMessage": "Must be a negative integer. Leave unset (default) to treat homopolymer gaps like regular gaps.",
                     "help_text": "Set HOMOPOLYMER_GAP_PENALTY parameter for dada2::dada denoising function. For explanation, see dada2::setDadaOpt()."
                 },
+                "chunk_taxassign": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of sequences to taxonomically assign per process.",
+                    "errorMessage": "Must be an integer >= 1.",
+                    "help_text": "Number of sequences to taxonomically assign per process. Decreasing this may speed up the pipeline when many CPUs are available. Setting to very low values (<10) is not recommended.",
+                    "default": 100
+                },
                 "slurm_account": {
                     "type": "string",
                     "description": "Account to use when submitting SLURM jobs.",


### PR DESCRIPTION
Summary of changes: 
- Taxonomic assignment is now parallelised, the number of sequences assigned in a single process is controlled with `--chunk_taxassign` (default: `100`)
- Taxonomic assignment outputs are now more generic, although some improvements could still be made
- `FILTER_SEQTAB` sequence filters are 'soft', meaning all sequences are taxonomically assigned and only removed later during `PHYLOSEQ_FILTER`
- Accumulation curve generation has been reactivated and is done in a separate optional process, controlled by `--accumulation_curve` (default: `true`)
- Output file formats have changed:
  - "OTU" is replaced with "seq_name", which is the `rlang::hash` hash of the sequence string
  - `phyloseq::otu_table`-style tables now have sequences as rows, not samples as rows
  - `summary_*.csv` output files now contain ASV nucleotide sequences
  - `PHYLOSEQ_UNFILTERED` `summary_*.csv` file contains the per-sequence filter passing information, and a separate file is output just containing filter information (`filters_*.csv`) -- this allows users to apply their own filtering criteria or to inspect filter stringency
  - `PHYLOSEQ_UNFILTERED` outputs now contain all sequences output from `dada2`, while `PHYLOSEQ_FILTER` outputs contain sequences that pass all sequence-level, abundance, taxonomic and sample-level filters 

Resolves issues:
- #16 
- #51 
- #66 
- #75 
- #76 