### PR TITLE
Empty read file handling

### DIFF
--- a/bin/accumulation_curve.R
+++ b/bin/accumulation_curve.R
@@ -32,7 +32,7 @@ process_packages <- c(
     "vegan",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ## check and define variables
 ps <- readRDS(ps_file)

--- a/bin/assignment_plot.R
+++ b/bin/assignment_plot.R
@@ -31,7 +31,7 @@ process_packages <- c(
     "tibble",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ## read in files
 fasta <-   Biostrings::readDNAStringSet(fasta)

--- a/bin/denoise.R
+++ b/bin/denoise.R
@@ -28,7 +28,7 @@ process_packages <- c(
     "dada2",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ### parse variables
 if ( dada_band_size == "null" ){

--- a/bin/error_model.R
+++ b/bin/error_model.R
@@ -48,7 +48,11 @@ reads_list <- # convert input reads list from Groovy format to R format
         reads, 
         pattern = "\\S+?\\.fastq\\.gz|\\S+?\\.fastq|\\S+?\\.fq\\.gz|\\S+?\\.fq" 
     ) %>% 
-    unlist()
+    unlist() %>%
+    # remove empty read files
+    .[lapply(., file.size) > 28]
+
+
 
 if(direction == "forward"){
     message(paste0("Modelling forward read error rates for primers: ", primers, " and flowcell: ", read_group))
@@ -60,30 +64,40 @@ if(direction == "forward"){
     stop ("Read direction must be 'forward', 'reverse' or 'single'!")
 }
 
-## Learn error rates 
-set.seed(1); err <- dada2::learnErrors(
-    reads_list, 
-    multithread = as.numeric(threads), 
-    nbases = 1e8,
-    randomize = FALSE, 
-    # qualityType = "FastqQuality",
-    qualityType = "Auto",
-    verbose=TRUE
-)
-    
+if ( length(reads_list) > 0){
+    ## Learn error rates 
+    set.seed(1); err <- dada2::learnErrors(
+        reads_list, 
+        multithread = as.numeric(threads), 
+        nbases = 1e8,
+        randomize = FALSE, 
+        # qualityType = "FastqQuality",
+        qualityType = "Auto",
+        verbose=TRUE
+    )
+
+    ## write out errors for diagnostics
+    readr::write_csv(as.data.frame(err$trans), paste0(read_group,"_",primers,"_err",direction_short,"_observed_transitions.csv"))
+    readr::write_csv(as.data.frame(err$err_out), paste0(read_group,"_",primers,"_err",direction_short,"_inferred_errors.csv"))
+
+    ## output error plots to see how well the algorithm modelled the errors in the different runs
+    p1 <- dada2::plotErrors(err, nominalQ = TRUE) + ggtitle(paste0(primers, " ", read_group," ",direction," Reads"))
+
+} else {
+    err <- NULL
+    p1 <- ggplot() + theme_void() + annotate(geom = "text", label = paste0("Read group '",read_group,"'\ncontains no reads for primers '",primers,"'"), x = 5, y = 5)
+}
+
+
+# write plot
+pdf(paste0(read_group,"_", primers, "_", direction_short,"_errormodel.pdf"), width = 11, height = 8 , paper="a4r")
+        plot(p1)
+    try(dev.off(), silent=TRUE)
 
 ## save output as .rds file
 saveRDS(err, paste0(read_group,"_",primers,"_errormodel",direction_short,".rds"))
 
-## write out errors for diagnostics
-readr::write_csv(as.data.frame(err$trans), paste0(read_group,"_",primers,"_err",direction_short,"_observed_transitions.csv"))
-readr::write_csv(as.data.frame(err$err_out), paste0(read_group,"_",primers,"_err",direction_short,"_inferred_errors.csv"))
 
-## output error plots to see how well the algorithm modelled the errors in the different runs
-p1 <- dada2::plotErrors(err, nominalQ = TRUE) + ggtitle(paste0(primers, " ", read_group," ",direction," Reads"))
-pdf(paste0(read_group,"_", primers, "_", direction_short,"_errormodel.pdf"), width = 11, height = 8 , paper="a4r")
-    plot(p1)
-try(dev.off(), silent=TRUE)
 
 # stop(" *** stopped manually *** ") ##########################################
 }, 

--- a/bin/error_model.R
+++ b/bin/error_model.R
@@ -26,7 +26,7 @@ process_packages <- c(
     "stringr",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ### run R code 
 if (!direction %in% c("forward","reverse","single")) { 

--- a/bin/filter_chimera.R
+++ b/bin/filter_chimera.R
@@ -29,7 +29,7 @@ process_packages <- c(
     "tibble",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ## check and define variables
 

--- a/bin/filter_frame.R
+++ b/bin/filter_frame.R
@@ -27,7 +27,7 @@ process_packages <- c(
     "tibble",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ## check and define variables
 

--- a/bin/filter_length.R
+++ b/bin/filter_length.R
@@ -26,7 +26,7 @@ process_packages <- c(
     "tibble",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ## check and define variables
 

--- a/bin/filter_phmm.R
+++ b/bin/filter_phmm.R
@@ -29,7 +29,7 @@ process_packages <- c(
     "tibble",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ## check and define variables
 

--- a/bin/filter_qualplots.R
+++ b/bin/filter_qualplots.R
@@ -58,104 +58,111 @@ if ( paired == "true" & seq_type == "illumina" ){
     fastqFs <- normalizePath(fwd_reads)
     fastqRs <- normalizePath(rev_reads)
 
-    if(length(fastqFs) == 0 ){
-        message(paste0("Sample ", fwd_reads, " Has no reads"))
-        return(NULL)
-    }
     if(!file.size(fastqFs) > 28) {
-        message(paste0("Sample ", fwd_reads, " Has no reads"))
-        return(NULL)
-    }
-    
-    Fquals <- seqateurs::get_qual_stats(fastqFs, n=n_reads)
-    Rquals <- seqateurs::get_qual_stats(fastqRs, n=n_reads)
-        
-    #Plot qualities
-    gg.Fqual <- Fquals %>% 
-        dplyr::select(Cycle, reads, starts_with("Q")) %>% 
-        tidyr::pivot_longer(cols = starts_with("Q")) %>% 
-        ggplot2::ggplot(aes(x = Cycle, y = value, colour = name)) + 
-        geom_line(data = Fquals, aes(y = QMean), color = "#66C2A5") + 
-        geom_line(data = Fquals, aes(y = Q25), color = "#FC8D62", linewidth = 0.25, linetype = "dashed") + 
-        geom_line(data = Fquals, aes(y = Q50), color = "#FC8D62", linewidth = 0.25) + 
-        geom_line(data = Fquals, aes(y = Q75), color = "#FC8D62", linewidth = 0.25, linetype = "dashed") + 
-        labs(x = "Reads position", y = "Quality Score") + ylim(c(0, NA))+
-        ggtitle(paste0(sample_primers," ",locus, " Forward Reads")) +
-        theme(legend.position = "bottom", plot.title = element_text(size = 10))
-    
-    gg.Rqual <- Rquals %>% 
-        dplyr::select(Cycle, reads, starts_with("Q")) %>% 
-        tidyr::pivot_longer(cols = starts_with("Q")) %>% 
-        ggplot2::ggplot(aes(x = Cycle, y = value, colour = name)) + 
-        geom_line(data = Rquals, aes(y = QMean), color = "#66C2A5") + 
-        geom_line(data = Rquals, aes(y = Q25), color = "#FC8D62", linewidth = 0.25, linetype = "dashed") + 
-        geom_line(data = Rquals, aes(y = Q50), color = "#FC8D62", linewidth = 0.25) + 
-        geom_line(data = Rquals, aes(y = Q75), color = "#FC8D62", linewidth = 0.25, linetype = "dashed") + 
-        labs(x = "Reads position", y = "Quality Score") + ylim(c(0, NA))+
-        ggtitle(paste0(sample_primers," ",locus, " Reverse Reads")) +
-        scale_x_continuous(breaks=seq(0,300,25)) +
-        theme(legend.position = "bottom", plot.title = element_text(size = 10))
-    
-    
-    gg.Fee <- Fquals %>% 
-        dplyr::select(Cycle, starts_with("EE")) %>% 
-        tidyr::pivot_longer(cols = starts_with("EE")) %>% 
-        dplyr::group_by(name) %>%  # Remove EE and replace with percentage at end? - i.e lower 10%
-        dplyr::mutate(cumsumEE = cumsum(value)) %>%
-        ggplot2::ggplot(aes(x = Cycle, y = log10(cumsumEE), colour = name)) + 
-        geom_point(size = 1) + 
-        geom_hline(yintercept = log10(1), color = "red") + 
-        geom_hline(yintercept = log10(2), color = "red") + 
-        geom_hline(yintercept = log10(3), color = "red") + 
-        geom_hline(yintercept = log10(5), color = "red") + 
-        geom_hline(yintercept = log10(7), color = "red") + 
-        geom_text(label = "MaxEE=1", aes(x = 0, y = log10(1), hjust = 0, vjust = 0), color = "red") + 
-        geom_text(label = "MaxEE=2", aes(x = 0, y = log10(2), hjust = 0, vjust = 0), color = "red") +
-        geom_text(label = "MaxEE=3", aes(x = 0, y = log10(3), hjust = 0, vjust = 0), color = "red") + 
-        geom_text(label = "MaxEE=5", aes(x = 0, y = log10(5), hjust = 0, vjust = 0), color = "red") + 
-        geom_text(label = "MaxEE=7", aes(x = 0, y = log10(7), hjust = 0, vjust = 0), color = "red") + 
-        labs(x = "Reads position", y = "Log10 Cumulative expected errors",
-            colour = "Read quantiles") + 
-        ggtitle(paste0(sample_primers," ",locus, " Forward Reads")) +
-        scale_x_continuous(breaks=seq(0,300,25)) +
-        theme(legend.position = "bottom", plot.title = element_text(size = 10))
+        message(paste0("Sample ", fwd_reads, " has no reads"))
+        if ( file_suffix == "pre" ){
+            empty_plot <- ggplot() + theme_void() + annotate(geom = "text", label = paste0("Sample '",sample_primers,"'\ncontains no reads pre-filtering"), x = 5, y = 5)
+        } else if ( file_suffix == "post" ) {
+            empty_plot <- ggplot() + theme_void() + annotate(geom = "text", label = paste0("Sample '",sample_primers,"'\ncontains no reads post-filtering"), x = 5, y = 5)
+        } else {
+            stop(paste0("'file_suffix' must be 'pre' or 'post'"))
+        }
+        gg.Fqual <- empty_plot
+        gg.Rqual <- empty_plot
+        gg.Fee <- empty_plot
+        gg.Ree <- empty_plot
 
-    
-    gg.Ree <- Rquals %>% 
-        dplyr::select(Cycle, starts_with("EE")) %>% 
-        tidyr::pivot_longer(cols = starts_with("EE")) %>% 
-        dplyr::group_by(name) %>% 
-        dplyr::mutate(cumsumEE = cumsum(value)) %>%
-        ggplot2::ggplot(aes(x = Cycle, y = log10(cumsumEE), colour = name)) + 
-        geom_point(size = 1) + 
-        geom_hline(yintercept = log10(1), color = "red") + 
-        geom_hline(yintercept = log10(2), color = "red") + 
-        geom_hline(yintercept = log10(3), color = "red") + 
-        geom_hline(yintercept = log10(5), color = "red") + 
-        geom_hline(yintercept = log10(7), color = "red") + 
-        geom_text(label = "MaxEE=1", aes(x = 0, y = log10(1), hjust = 0, vjust = 0), color = "red") + 
-        geom_text(label = "MaxEE=2", aes(x = 0, y = log10(2), hjust = 0, vjust = 0), color = "red") +
-        geom_text(label = "MaxEE=3", aes(x = 0, y = log10(3), hjust = 0, vjust = 0), color = "red") + 
-        geom_text(label = "MaxEE=5", aes(x = 0, y = log10(5), hjust = 0, vjust = 0), color = "red") + 
-        geom_text(label = "MaxEE=7", aes(x = 0, y = log10(7), hjust = 0, vjust = 0), color = "red") + 
-        labs(x = "Reads position", y = "Log10 Cumulative expected errors") +
-        ggtitle(paste0(sample_primers," ",locus," Reverse Reads")) +
-        scale_x_continuous(breaks=seq(0,300,25)) +
-        theme(legend.position = "bottom", plot.title = element_text(size = 10))
-    
-    if(!is.null(truncLen)){
-        gg.Fqual <- gg.Fqual +
-        geom_vline(aes(xintercept=truncLen[1]), colour="blue") +
-        annotate("text", x = truncLen[1]-10, y =2, label = paste0("Suggested truncLen = ", truncLen[1]), colour="blue")
-        gg.Fee <-gg.Fee +
-        geom_vline(aes(xintercept=truncLen[1]), colour="blue")+
-        annotate("text", x = truncLen[1]-10, y =-3, label = paste0("Suggested truncLen = ", truncLen[1]), colour="blue")
-        gg.Rqual <- gg.Rqual +
-        geom_vline(aes(xintercept=truncLen[2]), colour="blue")+
-        annotate("text", x = truncLen[1]-10, y =2, label = paste0("Suggested truncLen = ", truncLen[2]), colour="blue")
-        gg.Ree <- gg.Ree + 
-        geom_vline(aes(xintercept=truncLen[2]), colour="blue")+
-        annotate("text", x = truncLen[1]-10, y =-3, label = paste0("Suggested truncLen = ", truncLen[2]), colour="blue")
+    } else {
+        Fquals <- seqateurs::get_qual_stats(fastqFs, n=n_reads)
+        Rquals <- seqateurs::get_qual_stats(fastqRs, n=n_reads)
+            
+        #Plot qualities
+        gg.Fqual <- Fquals %>% 
+            dplyr::select(Cycle, reads, starts_with("Q")) %>% 
+            tidyr::pivot_longer(cols = starts_with("Q")) %>% 
+            ggplot2::ggplot(aes(x = Cycle, y = value, colour = name)) + 
+            geom_line(data = Fquals, aes(y = QMean), color = "#66C2A5") + 
+            geom_line(data = Fquals, aes(y = Q25), color = "#FC8D62", linewidth = 0.25, linetype = "dashed") + 
+            geom_line(data = Fquals, aes(y = Q50), color = "#FC8D62", linewidth = 0.25) + 
+            geom_line(data = Fquals, aes(y = Q75), color = "#FC8D62", linewidth = 0.25, linetype = "dashed") + 
+            labs(x = "Reads position", y = "Quality Score") + ylim(c(0, NA))+
+            ggtitle(paste0(sample_primers," ",locus, " Forward Reads")) +
+            theme(legend.position = "bottom", plot.title = element_text(size = 10))
+        
+        gg.Rqual <- Rquals %>% 
+            dplyr::select(Cycle, reads, starts_with("Q")) %>% 
+            tidyr::pivot_longer(cols = starts_with("Q")) %>% 
+            ggplot2::ggplot(aes(x = Cycle, y = value, colour = name)) + 
+            geom_line(data = Rquals, aes(y = QMean), color = "#66C2A5") + 
+            geom_line(data = Rquals, aes(y = Q25), color = "#FC8D62", linewidth = 0.25, linetype = "dashed") + 
+            geom_line(data = Rquals, aes(y = Q50), color = "#FC8D62", linewidth = 0.25) + 
+            geom_line(data = Rquals, aes(y = Q75), color = "#FC8D62", linewidth = 0.25, linetype = "dashed") + 
+            labs(x = "Reads position", y = "Quality Score") + ylim(c(0, NA))+
+            ggtitle(paste0(sample_primers," ",locus, " Reverse Reads")) +
+            scale_x_continuous(breaks=seq(0,300,25)) +
+            theme(legend.position = "bottom", plot.title = element_text(size = 10))
+        
+        
+        gg.Fee <- Fquals %>% 
+            dplyr::select(Cycle, starts_with("EE")) %>% 
+            tidyr::pivot_longer(cols = starts_with("EE")) %>% 
+            dplyr::group_by(name) %>%  # Remove EE and replace with percentage at end? - i.e lower 10%
+            dplyr::mutate(cumsumEE = cumsum(value)) %>%
+            ggplot2::ggplot(aes(x = Cycle, y = log10(cumsumEE), colour = name)) + 
+            geom_point(size = 1) + 
+            geom_hline(yintercept = log10(1), color = "red") + 
+            geom_hline(yintercept = log10(2), color = "red") + 
+            geom_hline(yintercept = log10(3), color = "red") + 
+            geom_hline(yintercept = log10(5), color = "red") + 
+            geom_hline(yintercept = log10(7), color = "red") + 
+            geom_text(label = "MaxEE=1", aes(x = 0, y = log10(1), hjust = 0, vjust = 0), color = "red") + 
+            geom_text(label = "MaxEE=2", aes(x = 0, y = log10(2), hjust = 0, vjust = 0), color = "red") +
+            geom_text(label = "MaxEE=3", aes(x = 0, y = log10(3), hjust = 0, vjust = 0), color = "red") + 
+            geom_text(label = "MaxEE=5", aes(x = 0, y = log10(5), hjust = 0, vjust = 0), color = "red") + 
+            geom_text(label = "MaxEE=7", aes(x = 0, y = log10(7), hjust = 0, vjust = 0), color = "red") + 
+            labs(x = "Reads position", y = "Log10 Cumulative expected errors",
+                colour = "Read quantiles") + 
+            ggtitle(paste0(sample_primers," ",locus, " Forward Reads")) +
+            scale_x_continuous(breaks=seq(0,300,25)) +
+            theme(legend.position = "bottom", plot.title = element_text(size = 10))
+
+        
+        gg.Ree <- Rquals %>% 
+            dplyr::select(Cycle, starts_with("EE")) %>% 
+            tidyr::pivot_longer(cols = starts_with("EE")) %>% 
+            dplyr::group_by(name) %>% 
+            dplyr::mutate(cumsumEE = cumsum(value)) %>%
+            ggplot2::ggplot(aes(x = Cycle, y = log10(cumsumEE), colour = name)) + 
+            geom_point(size = 1) + 
+            geom_hline(yintercept = log10(1), color = "red") + 
+            geom_hline(yintercept = log10(2), color = "red") + 
+            geom_hline(yintercept = log10(3), color = "red") + 
+            geom_hline(yintercept = log10(5), color = "red") + 
+            geom_hline(yintercept = log10(7), color = "red") + 
+            geom_text(label = "MaxEE=1", aes(x = 0, y = log10(1), hjust = 0, vjust = 0), color = "red") + 
+            geom_text(label = "MaxEE=2", aes(x = 0, y = log10(2), hjust = 0, vjust = 0), color = "red") +
+            geom_text(label = "MaxEE=3", aes(x = 0, y = log10(3), hjust = 0, vjust = 0), color = "red") + 
+            geom_text(label = "MaxEE=5", aes(x = 0, y = log10(5), hjust = 0, vjust = 0), color = "red") + 
+            geom_text(label = "MaxEE=7", aes(x = 0, y = log10(7), hjust = 0, vjust = 0), color = "red") + 
+            labs(x = "Reads position", y = "Log10 Cumulative expected errors") +
+            ggtitle(paste0(sample_primers," ",locus," Reverse Reads")) +
+            scale_x_continuous(breaks=seq(0,300,25)) +
+            theme(legend.position = "bottom", plot.title = element_text(size = 10))
+        
+        if(!is.null(truncLen)){
+            gg.Fqual <- gg.Fqual +
+            geom_vline(aes(xintercept=truncLen[1]), colour="blue") +
+            annotate("text", x = truncLen[1]-10, y =2, label = paste0("Suggested truncLen = ", truncLen[1]), colour="blue")
+            gg.Fee <-gg.Fee +
+            geom_vline(aes(xintercept=truncLen[1]), colour="blue")+
+            annotate("text", x = truncLen[1]-10, y =-3, label = paste0("Suggested truncLen = ", truncLen[1]), colour="blue")
+            gg.Rqual <- gg.Rqual +
+            geom_vline(aes(xintercept=truncLen[2]), colour="blue")+
+            annotate("text", x = truncLen[1]-10, y =2, label = paste0("Suggested truncLen = ", truncLen[2]), colour="blue")
+            gg.Ree <- gg.Ree + 
+            geom_vline(aes(xintercept=truncLen[2]), colour="blue")+
+            annotate("text", x = truncLen[1]-10, y =-3, label = paste0("Suggested truncLen = ", truncLen[2]), colour="blue")
+        }
     }
     
     Qualplots <- (gg.Fqual + gg.Rqual) / (gg.Fee + gg.Ree)
@@ -167,13 +174,17 @@ if ( paired == "true" & seq_type == "illumina" ){
     ### single-end Nanopore reads
     fastqSs <- normalizePath(single_reads)
 
-    if(length(fastqSs) == 0 ){
-        message(paste0("Sample ", single_reads, " Has no reads"))
-        return(NULL)
-    }
     if(!file.size(fastqSs) > 28) {
-        message(paste0("Sample ", single_reads, " Has no reads"))
-        return(NULL)
+        message(paste0("Sample ", single_reads, " has no reads"))
+        if ( file_suffix == "pre" ){
+            empty_plot <- ggplot() + theme_void() + annotate(geom = "text", label = paste0("Sample '",sample_primers,"'\ncontains no reads pre-filtering"), x = 5, y = 5)
+        } else if ( file_suffix == "post" ) {
+            empty_plot <- ggplot() + theme_void() + annotate(geom = "text", label = paste0("Sample '",sample_primers,"'\ncontains no reads post-filtering"), x = 5, y = 5)
+        } else {
+            stop(paste0("'file_suffix' must be 'pre' or 'post'"))
+        }
+        gg.Squal <- empty_plot
+        gg.See <- empty_plot
     }
     
     Squals <- seqateurs::get_qual_stats(fastqSs, n=n_reads)
@@ -232,9 +243,6 @@ if ( paired == "true" & seq_type == "illumina" ){
     Qualplots <- gg.Squal / gg.See
 
     ggsave(paste0("qualplots_",file_suffix,"_",sample_primers,".pdf"), Qualplots, width = 11, height = 8)
-
-
-
 
 } else {
     stop ( "Currently unsupported sequencing type -- check samplesheet" )

--- a/bin/filter_qualplots.R
+++ b/bin/filter_qualplots.R
@@ -31,7 +31,7 @@ process_packages <- c(
     "tidyr",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ### process variables 
 # split reads_paths into individual file paths (or keep if single reads)

--- a/bin/joint_tax.R
+++ b/bin/joint_tax.R
@@ -25,7 +25,7 @@ process_packages <- c(
     "tibble",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ## check and define variables 
 propagate_tax <-        TRUE

--- a/bin/make_seqtab_paired.R
+++ b/bin/make_seqtab_paired.R
@@ -30,7 +30,7 @@ process_packages <- c(
     "tibble",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ### process variables 
 if ( is.na(concat_unmerged) || concat_unmerged %in%  c("NA", "FALSE", "F")) {

--- a/bin/make_seqtab_paired.R
+++ b/bin/make_seqtab_paired.R
@@ -89,17 +89,40 @@ seqs_R_list <- # convert input sequences list from Groovy format to R format
 seqs_R_extracted <- lapply(seqs_R_list, readRDS)
 names(seqs_R_extracted) <- sample_primers_list
 
-if (unlist(seqs_F_extracted) %>% is.null || unlist(seqs_R_extracted) %>% is.null){
+
+# get names of NULL elements for F and R sequences
+empty_seqs_F <- seqs_F_extracted[sapply(seqs_F_extracted, is.null)] %>% names
+empty_seqs_R <- seqs_R_extracted[sapply(seqs_R_extracted, is.null)] %>% names
+
+# remove empty sequence elements
+seqs_F_pass <- seqs_F_extracted[!sapply(seqs_F_extracted, is.null)]
+seqs_R_pass <- seqs_R_extracted[!sapply(seqs_R_extracted, is.null)]
+
+# if either passing seq list is empty, throw error
+if (length(seqs_F_pass) == 0 || length(seqs_R_pass) == 0){
     stop(paste0("\n***\nZero sequences made it through denoising for read group '",read_group,"' and primers '",primers,"'.\nConsider changing your read filtering parameters.\n***\n"))
 }
+
+# remove read files from list if there are NULL elements associated with them
+reads_F_pass <- reads_F_list[!names(reads_F_list) %in% empty_seqs_F]
+reads_R_pass <- reads_R_list[!names(reads_R_list) %in% empty_seqs_R]
+
+# if either passing reads list is empty, throw error
+if (length(reads_F_pass) == 0 || length(reads_R_pass) == 0){
+    stop(paste0("\n***\nZero reads made it through denoising for read group '",read_group,"' and primers '",primers,"'.\nConsider changing your read filtering parameters.\n***\n"))
+}
+
+# vector of samples that pass (ie. have data)
+sample_primers_pass <- sample_primers_list[!sample_primers_list %in% c(empty_seqs_F, empty_seqs_R)]
+sample_primers_fail <- sample_primers_list[sample_primers_list %in% c(empty_seqs_F, empty_seqs_R)]
 
 ## merge pairs, keeping unmerged reads only if concat_unmerged is TRUE
 mergers <- 
     dada2::mergePairs(
-        dadaF = seqs_F_extracted,
-        derepF = reads_F_list,
-        dadaR = seqs_R_extracted,
-        derepR= reads_R_list,
+        dadaF = seqs_F_pass,
+        derepF = reads_F_pass,
+        dadaR = seqs_R_pass,
+        derepR= reads_R_pass,
         verbose = TRUE,
         minOverlap = 12,
         trimOverhang = TRUE,
@@ -110,7 +133,7 @@ mergers <-
 ## reformat mergers as a list with one element if there is only one sample
 if ( class(mergers) == "data.frame" ) {
     mergers <- list(mergers)
-    names(mergers) <- sample_primers_list
+    names(mergers) <- sample_primers_pass
 }
 
 ## TODO: write out unmerged reads? (pull from functions.R)
@@ -124,8 +147,8 @@ if ( concat_unmerged ) {
             # Get index of unmerged reads in table
             unmerged_index <- which(!mergers[[i]]$accept)
             # Get the forward and reverse reads for those reads
-            unmerged_fwd <- seqs_F[[i]]$sequence[mergers[[i]]$forward[unmerged_index]]
-            unmerged_rev <- seqs_R[[i]]$sequence[mergers[[i]]$reverse[unmerged_index]]
+            unmerged_fwd <- seqs_F_pass[[i]]$sequence[mergers[[i]]$forward[unmerged_index]]
+            unmerged_rev <- seqs_R_pass[[i]]$sequence[mergers[[i]]$reverse[unmerged_index]]
             
             unmerged_concat <- paste0(unmerged_fwd, "NNNNNNNNNN", rc(unmerged_rev))
             
@@ -153,10 +176,13 @@ if ( class(mergers) == "list") {
 
 }
 
+# create readsout output table
 sapply(mergers, getN) %>% 
     as.data.frame() %>% 
     magrittr::set_colnames("pairs") %>%
     tibble::rownames_to_column(var = "sample_primers") %>%
+    # add 0 abundance samples in with read counts of 0
+    tibble::add_row(sample_primers = sample_primers_fail, pairs = 0) %>%
     dplyr::mutate(
         read_group = read_group,
         primers = primers,
@@ -197,6 +223,10 @@ seqtab_tibble <-
     dplyr::select(-sequence) %>% # remove sequence
     tidyr::pivot_wider(names_from = sample_primers, values_from = abundance)
 
+# add 0 abundance samples to seqtab
+if (length(sample_primers_fail) > 0){
+    seqtab_tibble[sample_primers_fail] <- 0L
+}
 
 # save DSS as .fasta
 write_fasta(seq_DSS, file = paste0(read_group, "_", primers, "_seqs.fasta"))
@@ -204,8 +234,8 @@ write_fasta(seq_DSS, file = paste0(read_group, "_", primers, "_seqs.fasta"))
 # save seqtab_tidy as .csv
 readr::write_csv(seqtab_tibble, paste0(read_group, "_", primers, "_seqtab_tibble.csv"))
 
-
 # stop(" *** stopped manually *** ") ##########################################
+
 }, 
 finally = {
     ### save R environment if script throws error code

--- a/bin/make_seqtab_paired.R
+++ b/bin/make_seqtab_paired.R
@@ -89,6 +89,10 @@ seqs_R_list <- # convert input sequences list from Groovy format to R format
 seqs_R_extracted <- lapply(seqs_R_list, readRDS)
 names(seqs_R_extracted) <- sample_primers_list
 
+if (unlist(seqs_F_extracted) %>% is.null || unlist(seqs_R_extracted) %>% is.null){
+    stop(paste0("\n***\nZero sequences made it through denoising for read group '",read_group,"' and primers '",primers,"'.\nConsider changing your read filtering parameters.\n***\n"))
+}
+
 ## merge pairs, keeping unmerged reads only if concat_unmerged is TRUE
 mergers <- 
     dada2::mergePairs(
@@ -105,8 +109,8 @@ mergers <-
 
 ## reformat mergers as a list with one element if there is only one sample
 if ( class(mergers) == "data.frame" ) {
-  mergers <- list(mergers)
-  names(mergers) <- sample_primers_list
+    mergers <- list(mergers)
+    names(mergers) <- sample_primers_list
 }
 
 ## TODO: write out unmerged reads? (pull from functions.R)
@@ -199,8 +203,6 @@ write_fasta(seq_DSS, file = paste0(read_group, "_", primers, "_seqs.fasta"))
 
 # save seqtab_tidy as .csv
 readr::write_csv(seqtab_tibble, paste0(read_group, "_", primers, "_seqtab_tibble.csv"))
-
-
 
 
 # stop(" *** stopped manually *** ") ##########################################

--- a/bin/make_seqtab_single.R
+++ b/bin/make_seqtab_single.R
@@ -28,7 +28,7 @@ process_packages <- c(
     "tibble",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 
 ### run R code

--- a/bin/make_seqtab_single.R
+++ b/bin/make_seqtab_single.R
@@ -61,6 +61,29 @@ seqs_list <- # convert input sequences list from Groovy format to R format
 seqs_extracted <- lapply(seqs_list, readRDS)
 names(seqs_extracted) <- sample_primers_list
 
+# get names of NULL elements for sequences
+empty_seqs <- seqs_extracted[sapply(seqs_extracted, is.null)] %>% names
+
+# remove empty sequence elements
+seqs_pass <- seqs_extracted[!sapply(seqs_extracted, is.null)]
+
+# if either passing seq list is empty, throw error
+if (length(seqs_pass) == 0 ){
+    stop(paste0("\n***\nZero sequences made it through denoising for read group '",read_group,"' and primers '",primers,"'.\nConsider changing your read filtering parameters.\n***\n"))
+}
+
+# remove read files from list if there are NULL elements associated with them
+reads_pass <- reads_list[!names(reads_list) %in% empty_seqs]
+
+# if passing reads list is empty, throw error
+if (length(reads_pass) == 0){
+    stop(paste0("\n***\nZero reads made it through denoising for read group '",read_group,"' and primers '",primers,"'.\nConsider changing your read filtering parameters.\n***\n"))
+}
+
+# vector of samples that pass (ie. have data)
+sample_primers_pass <- sample_primers_list[!sample_primers_list %in% empty_seqs]
+sample_primers_fail <- sample_primers_list[sample_primers_list %in% empty_seqs]
+
 ## reformat seqs_extracted as a list with one element if there is only one sample
 if ( class(seqs_extracted) == "data.frame" ) {
   seqs_extracted <- list(seqs_extracted)
@@ -80,6 +103,8 @@ sapply(seqs_extracted, getN) %>%
     as.data.frame() %>% 
     magrittr::set_colnames("pairs") %>%
     tibble::rownames_to_column(var = "sample_primers") %>%
+    # add 0 abundance samples in with read counts of 0
+    tibble::add_row(sample_primers = sample_primers_fail, pairs = 0) %>%
     dplyr::mutate(
         read_group = read_group,
         primers = primers,
@@ -119,6 +144,10 @@ seqtab_tibble <-
     dplyr::select(-sequence) %>% # remove sequence
     tidyr::pivot_wider(names_from = sample_primers, values_from = abundance)
 
+# add 0 abundance samples to seqtab
+if (length(sample_primers_fail) > 0){
+    seqtab_tibble[sample_primers_fail] <- 0L
+}
 
 # save DSS as .fasta
 write_fasta(seq_DSS, file = paste0(read_group, "_", primers, "_seqs.fasta"))

--- a/bin/merge_filters.R
+++ b/bin/merge_filters.R
@@ -28,7 +28,7 @@ process_packages <- c(
     "tibble",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ## check and define variables
 

--- a/bin/merge_tax.R
+++ b/bin/merge_tax.R
@@ -24,7 +24,7 @@ process_packages <- c(
     "tibble",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ## check and define variables
 taxtab_list <- # convert Groovy to R list format

--- a/bin/miseq_qc.R
+++ b/bin/miseq_qc.R
@@ -28,7 +28,7 @@ process_packages <- c(
     "tidyr",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 #### TODO: Pull stats from top of index_switching.pdf and print to a final run report
 ### also flag index combos that have higher than average + (some stat)

--- a/bin/parse_inputs.R
+++ b/bin/parse_inputs.R
@@ -31,7 +31,7 @@ process_packages <- c(
     "tidyr",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ### process variables
 

--- a/bin/parse_inputs.R
+++ b/bin/parse_inputs.R
@@ -96,7 +96,7 @@ if (any(duplicated(samplesheet_df$sample))) {
 ## any spaces or commas in fields?
 # if 'read_group' is present, validate it too, otherwise just validate other columns
 if ("read_group" %in% ssc){
-    if ( any(c(samplesheet_df$sample, samplesheet_df$primers, samplesheet$read_group) %>% stringr::str_detect(., "^[^\\s,]+$", negate = T)) ){
+    if ( any(c(samplesheet_df$sample, samplesheet_df$primers, samplesheet_df$read_group) %>% stringr::str_detect(., "^[^\\s,]+$", negate = T)) ){
         stop(paste0(sse, "'sample', 'primers' and 'read_group' values must not contain spaces or commas."))
     } 
 } else {

--- a/bin/phyloseq_clustered.R
+++ b/bin/phyloseq_clustered.R
@@ -34,7 +34,7 @@ process_packages <- c(
     "tidyr",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ## check and define variables
 ps <- readRDS(ps_file)

--- a/bin/phyloseq_filter.R
+++ b/bin/phyloseq_filter.R
@@ -55,9 +55,9 @@ if(target_genus == "NA"){ target_genus <- NA }
 if(target_species == "NA"){ target_species <- NA }
 
 # convert "NA" strings to true NA, or convert number strings to numeric
-if(min_sample_reads %in% c(0, "NA")){ min_sample_reads <- NA } else { min_sample_reads <- as.numeric(min_sample_reads) }
-if(min_taxa_reads %in% c(0, "NA")){ min_taxa_reads <- NA } else { min_taxa_reads <- as.numeric(min_taxa_reads) }  
-if(min_taxa_ra %in% c(0, "NA")){ min_taxa_ra <- NA } else { min_taxa_ra <- as.numeric(min_taxa_ra) } 
+if(min_sample_reads %in% c(0, "NA", NA)){ min_sample_reads <- NA } else { min_sample_reads <- as.numeric(min_sample_reads) }
+if(min_taxa_reads %in% c(0, "NA", NA)){ min_taxa_reads <- NA } else { min_taxa_reads <- as.numeric(min_taxa_reads) }  
+if(min_taxa_ra %in% c(0, "NA", NA)){ min_taxa_ra <- NA } else { min_taxa_ra <- as.numeric(min_taxa_ra) } 
 
 cluster_threshold <- suppressWarnings(as.integer(cluster_threshold))
 
@@ -229,17 +229,17 @@ if(!is.na(min_taxa_reads) & is.na(min_taxa_ra)){
 }
 
 #Remove all samples under the minimum read threshold 
-if(!is.na(min_sample_reads) || min_sample_reads > 0){
+if(!is.na(min_sample_reads)){
 
-    if (all(phyloseq::sample_sums(ps_abfiltered)<min_sample_reads)) {
+    if (all(phyloseq::sample_sums(ps_abfiltered) < min_sample_reads)) {
         stop(paste0("ERROR: No samples contained reads above the minimum threshold of ", min_sample_reads, " for primers '", primers, "' -- consider lowering this value"))
     }
     
     ps_sampfiltered <- ps_abfiltered %>%
-        phyloseq::prune_samples(phyloseq::sample_sums(.)>=min_sample_reads, .) %>% 
+        phyloseq::prune_samples(phyloseq::sample_sums(.) >= min_sample_reads, .) %>% 
         phyloseq::filter_taxa(function(x) mean(x) > 0, TRUE) #Drop missing taxa from table
 
-} else if (min_sample_reads == 0 || is.na(min_sample_reads) ) {
+} else if (is.na(min_sample_reads) ) {
 
     if (!quiet){message(paste0("No minimum sample reads filter set - skipping this filter"))}
 
@@ -247,6 +247,8 @@ if(!is.na(min_sample_reads) || min_sample_reads > 0){
         phyloseq::prune_samples(phyloseq::sample_sums(.)>=0,.) %>%
         phyloseq::filter_taxa(function(x) mean(x) > 0, TRUE) #Drop missing taxa from table
 
+} else {
+    stop(paste0("--min_sample_reads value is '",min_sample_reads,"', which is not allowed."))
 }
 
 # Message how many were removed

--- a/bin/phyloseq_filter.R
+++ b/bin/phyloseq_filter.R
@@ -39,7 +39,7 @@ process_packages <- c(
     "tidyr",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ## check and define variables
 ps <- readRDS(ps)

--- a/bin/phyloseq_merge.R
+++ b/bin/phyloseq_merge.R
@@ -29,7 +29,7 @@ process_packages <- c(
     "tidyr",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ## check and define variables
 ps_unfiltered <- # convert Groovy to R list format

--- a/bin/phyloseq_unfiltered.R
+++ b/bin/phyloseq_unfiltered.R
@@ -37,7 +37,7 @@ process_packages <- c(
     "vegan",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ## check and define variables
 taxtab <- readr::read_csv(taxtab_file)

--- a/bin/priors.R
+++ b/bin/priors.R
@@ -13,6 +13,7 @@ primers                     <- args$primers
 direction                   <- args$direction
 read_group                  <- args$read_group
 priors                      <- args$priors
+prior_min_samples           <- args$prior_min_samples
 
 sys.source(paste0(args$projectDir,"/bin/functions.R"), envir = .GlobalEnv)
 
@@ -35,26 +36,38 @@ if (direction == "forward") { # recode read direction as "F" or "R"
 } else {
     stop(" Input reads direction needs to be 'forward' or 'reverse'! ")
 }
+
+prior_min_samples <- as.numeric(prior_min_samples)
+
 ## parse priors list
 priors_list <- # convert input priors .rds file list from Groovy format to R format
     stringr::str_extract_all(
         priors, 
         pattern = "\\S+?\\.rds" 
         ) %>% 
-    unlist()
+    unlist() 
 
 priors_tibble <- tibble::tibble() # new tibble
 for (i in 1:length(priors_list)) { # loop through .rds files, adding distinct sequences to tibble
     seq <- readRDS(priors_list[i])$sequence %>% tibble::as_tibble_col(column_name = "sequence") %>% dplyr::distinct()
     priors_tibble <- rbind(priors_tibble, seq)
 }
+if (nrow(priors_tibble) > 0){
+    # keep only sequences that appear in at least --priors_min_samples samples
+    priors <- priors_tibble %>% 
+        dplyr::group_by(sequence) %>% 
+        dplyr::summarise(n = n()) %>% 
+        dplyr::filter(n >= prior_min_samples) %>%
+        dplyr::pull(sequence)
 
-# keep only sequences that appear more than once (ie. are in more than one sample)
-priors <- priors_tibble %>% 
-            dplyr::group_by(sequence) %>% 
-            dplyr::summarise(n = n()) %>% 
-            dplyr::filter(n>1) %>%
-            dplyr::pull(sequence)
+    # check there are sequences remaining after filtering
+    if ( identical(priors, character(0)) ){
+        stop(paste0("\n***\nThere were ",nrow(priors_tibble)," input prior sequences for read group '",read_group,"' and primers '", primers, "', but all of them were removed during filtering.\nConsider decreasing the value of --prior_min_samples, or disabling --high_sensitivity, or checking that enough reads are passing through the read filtering steps.\n***"))
+    }
+
+} else {
+    priors <- NULL
+}
 
 saveRDS(priors, paste0(read_group,"_",primers,"_priors",direction_short,".rds"))
 

--- a/bin/priors.R
+++ b/bin/priors.R
@@ -24,7 +24,7 @@ process_packages <- c(
     "tibble",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ### run R code
 if (direction == "forward") { # recode read direction as "F" or "R"

--- a/bin/read_filter.R
+++ b/bin/read_filter.R
@@ -52,58 +52,102 @@ if ( paired == "true" ) {
 
 if ( paired == "true" & seq_type == "illumina" ) {
 
-    # filter and trim paired-end reads
-    set.seed(1); res <- dada2::filterAndTrim(
-        fwd = fwd_reads, 
-        filt = paste0(sample_primers,"_",locus,"_",primers,"_filter_R1.fastq.gz"), # gets saved to working dir
-        rev = rev_reads, 
-        filt.rev = paste0(sample_primers,"_",locus,"_",primers,"_filter_R2.fastq.gz"), # gets saved to working dir
-        minLen = as.numeric(read_min_length), 
-        maxLen = as.numeric(read_max_length), 
-        maxEE = as.numeric(read_max_ee), 
-        truncLen = as.numeric(read_trunc_length),
-        trimLeft = as.numeric(read_trim_left), 
-        trimRight = as.numeric(read_trim_right), 
-        rm.phix = TRUE, 
-        multithread = FALSE, 
-        compress = TRUE, 
-        verbose = FALSE,
-        n = 1e5
-    )
+    ## check if input files have reads in them
+    if (file.info(fwd_reads)$size > 0 && file.info(rev_reads)$size > 0){
+        # filter and trim paired-end reads
+        set.seed(1); res <- dada2::filterAndTrim(
+            fwd = fwd_reads, 
+            filt = paste0(sample_primers,"_",locus,"_",primers,"_filter_R1.fastq.gz"), # gets saved to working dir
+            rev = rev_reads, 
+            filt.rev = paste0(sample_primers,"_",locus,"_",primers,"_filter_R2.fastq.gz"), # gets saved to working dir
+            minLen = as.numeric(read_min_length), 
+            maxLen = as.numeric(read_max_length), 
+            maxEE = as.numeric(read_max_ee), 
+            truncLen = as.numeric(read_trunc_length),
+            trimLeft = as.numeric(read_trim_left), 
+            trimRight = as.numeric(read_trim_right), 
+            rm.phix = TRUE, 
+            multithread = FALSE, 
+            compress = TRUE, 
+            verbose = FALSE,
+            n = 1e5
+        )
+    } else {
+        message("Input file size is 0, skipping read trimming")
+    }
+
+    # create output files if they don't exist
+    if (!file.exists(paste0(sample_primers,"_",locus,"_",primers,"_filter_R1.fastq.gz"))){
+        file.create(paste0(sample_primers,"_",locus,"_",primers,"_filter_R1.fastq.gz"))
+        empty_forward <- TRUE
+    } else {
+        empty_forward <- FALSE
+    }
+    if (!file.exists(paste0(sample_primers,"_",locus,"_",primers,"_filter_R2.fastq.gz"))){
+        file.create(paste0(sample_primers,"_",locus,"_",primers,"_filter_R2.fastq.gz"))
+        empty_reverse <- TRUE
+    } else {
+        empty_reverse <- FALSE
+    }
+    if (empty_forward & empty_reverse ){
+        empty_reads <- TRUE
+    } else if ( !empty_forward & !empty_reverse ) {
+        empty_reads <- FALSE
+    } else {
+        stop(paste0("Forward reads empty is ",empty_forward," while reverse read empty is ",empty_reverse))
+    }
 
 } else if ( paired == "false" & seq_type == "nanopore" ) {
+    
+    ## check if input file has reads in it
+    if (file.info(single_reads)$size > 0){
+        # filter and trim single-end reads
+        set.seed(1); res <- dada2::filterAndTrim(
+            fwd = single_reads, 
+            filt = paste0(sample_primers,"_",locus,"_",primers,"_filter_R0.fastq.gz"), # gets saved to working dir
+            minLen = as.numeric(read_min_length), 
+            maxLen = as.numeric(read_max_length), 
+            maxEE = as.numeric(read_max_ee), 
+            truncLen = as.numeric(read_trunc_length),
+            trimLeft = as.numeric(read_trim_left), 
+            trimRight = as.numeric(read_trim_right), 
+            rm.phix = TRUE, 
+            multithread = FALSE, 
+            compress = TRUE, 
+            verbose = FALSE,
+            n = 1e4
+        )
+    } else {
+        message("Input file size is 0, skipping read trimming")
+    }
 
-    # filter and trim single-end reads
-    set.seed(1); res <- dada2::filterAndTrim(
-        fwd = single_reads, 
-        filt = paste0(sample_primers,"_",locus,"_",primers,"_filter_R0.fastq.gz"), # gets saved to working dir
-        minLen = as.numeric(read_min_length), 
-        maxLen = as.numeric(read_max_length), 
-        maxEE = as.numeric(read_max_ee), 
-        truncLen = as.numeric(read_trunc_length),
-        trimLeft = as.numeric(read_trim_left), 
-        trimRight = as.numeric(read_trim_right), 
-        rm.phix = TRUE, 
-        multithread = FALSE, 
-        compress = TRUE, 
-        verbose = FALSE,
-        n = 1e4
-    )
+    # create output file if they don't exist
+    if (!file.exists(paste0(sample_primers,"_",locus,"_",primers,"_filter_R0.fastq.gz"))){
+        file.create(paste0(sample_primers,"_",locus,"_",primers,"_filter_R0.fastq.gz"))
+        empty_reads <- TRUE
+    } else {
+        empty_reads <- FALSE
+    }
 
 } else {
     stop ( "Currently unsupported sequencing type -- check samplesheet" )
 }
 
-## extract output read counts and save to file
-reads_out <- res %>%
-    tibble::as_tibble() %>%
-    dplyr::pull(reads.out)
 
+## extract output read counts and save to file
+if ( !empty_reads ){
+    reads_out <- res %>%
+        tibble::as_tibble() %>%
+        dplyr::pull(reads.out)
+} else {
+    reads_out <- 0
+}
 out_vector <- c("read_filter", sample_primers, read_group, primers, reads_out, reads_out) 
 
 rbind(out_vector) %>%
     tibble::as_tibble() %>%
     readr::write_csv(paste0("read_filter_",sample_primers,"_",primers,"_readsout.csv"), col_names = F)
+
 
 # stop(" *** stopped manually *** ") ##########################################
 }, 

--- a/bin/read_filter.R
+++ b/bin/read_filter.R
@@ -34,7 +34,7 @@ process_packages <- c(
     "stringr",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ### process variables 
 # split reads_paths into individual file paths (or keep if single reads)

--- a/bin/read_tracking.R
+++ b/bin/read_tracking.R
@@ -28,7 +28,7 @@ process_packages <- c(
     "tidyr",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ## check and define variables 
 rt_samples <- # convert Groovy to R list format

--- a/bin/tax_blast.R
+++ b/bin/tax_blast.R
@@ -31,7 +31,7 @@ process_packages <- c(
     "tidyr",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ### TODO: Add explicit taxonomic ranks option to loci parameters
 

--- a/bin/tax_idtaxa.R
+++ b/bin/tax_idtaxa.R
@@ -30,7 +30,7 @@ process_packages <- c(
     "tibble",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ## check and define variables 
 return_ids <-           TRUE

--- a/bin/tax_summary.R
+++ b/bin/tax_summary.R
@@ -32,7 +32,7 @@ process_packages <- c(
     "stringr",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ## check and define variables
 # read in fasta as tibble

--- a/bin/tax_summary_merge.R
+++ b/bin/tax_summary_merge.R
@@ -22,7 +22,7 @@ process_packages <- c(
     NULL
     )
 
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ## check and define variables
 # read in taxtabs and store as list of tibbles

--- a/bin/train_idtaxa.R
+++ b/bin/train_idtaxa.R
@@ -26,7 +26,7 @@ process_packages <- c(
     "tibble",
     NULL
 )
-invisible(lapply(head(process_packages,-1), library, character.only = TRUE, warn.conflicts = FALSE))
+suppressPackageStartupMessages(invisible(lapply(process_packages, library, character.only = TRUE, warn.conflicts = FALSE)))
 
 ## check and define variables 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -166,6 +166,7 @@ These options generally will not need to be changed by regular users.
 | `--primer_error_rate` | Maximum error rate when detecting primers ([`cutadapt -e`](https://cutadapt.readthedocs.io/en/v4.7/reference.html#adapter-finding-options)) | Number >= `0` | `1` |
 | `--primer_n_trim` | Recognise `N` bases in reads when detecting primers ([`cutadapt --match-read-wildcards`](https://cutadapt.readthedocs.io/en/v4.7/reference.html#adapter-finding-options)) | Boolean (`true`/`false`) | `false` |
 | `--high_sensitivity` | Infer ASVs with `dada2` [pseudo-pooling](https://benjjneb.github.io/dada2/pseudo.html) mode | Boolean (`true`/`false`) | `true` |
+| `--prior_min_samples` | Minimum number of samples an ASV must be present in to be classfied as a "prior" sequence with `--high_sensitivity` | Integer > `0` | `2` |
 | `--dada_band_size` | Set `BAND_SIZE` parameter for `dada2::dada()` | Integer | `16` |
 | `--dada_homopolymer` | Set `HOMOPOLYMER_GAP_PENALTY` parameter for `dada2::dada()` | Integer < `0` | `null` |
 | `--chimera_sample_frac` | Minimum fraction of samples in which a sequence must be flagged as a chimera to be classified a chimera (see [`dada2::isBimeraDenovoTable(minSampleFraction)`](https://rdrr.io/bioc/dada2/man/isBimeraDenovoTable.html)) | Number `0`-`1` | `0.9` |

--- a/nextflow.config
+++ b/nextflow.config
@@ -27,6 +27,7 @@ params {
 
     /// TODO: replace this with equivalent input-file option
     high_sensitivity            = true                              // enable dada2 high-sensitivity (pseudo-pooling) mode; boolean
+    prior_min_samples           = 2                                 // minimum number of samples an ASV must be present in to be classfied as a "prior" when --high_sensitivity; integer > 0
     dada_band_size              = 16                                // set BAND_SIZE parameter for dada2::dada function in 'denoise.R'; integer
     dada_homopolymer            = null                              // set HOMOPOLYMER_GAP_PENALTY parameter for dada2::dada function in 'denoise.R'; integer < 0
 

--- a/nextflow/modules/priors.nf
+++ b/nextflow/modules/priors.nf
@@ -6,6 +6,7 @@ process PRIORS {
 
     input:
     tuple val(direction), val(primers), val(read_group), path(priors)
+    val(prior_min_samples)
 
     output:   
     tuple val(direction), val(primers), val(read_group), path("*_priors{F,R,S}.rds"),              emit: priors
@@ -25,7 +26,8 @@ process PRIORS {
         --primers "$primers" \
         --direction "$direction" \
         --read_group "$read_group" \
-        --priors "$priors" 
+        --priors "$priors" \
+        --prior_min_samples "$prior_min_samples" 
         
     """
     

--- a/nextflow/subworkflows/dada2.nf
+++ b/nextflow/subworkflows/dada2.nf
@@ -121,7 +121,10 @@ workflow DADA2 {
                 .set { ch_priors_f_pre }
 
             //// get priors for forward reads
-            PRIORS_F ( ch_priors_f_pre )
+            PRIORS_F ( 
+                ch_priors_f_pre,
+                params.prior_min_samples
+            )
 
             /// combine with forward read data channel
             ch_denoise1_input_forward
@@ -153,7 +156,10 @@ workflow DADA2 {
                 .set { ch_priors_r_pre }
 
             //// get priors for reverse reads
-            PRIORS_R ( ch_priors_r_pre )
+            PRIORS_R ( 
+                ch_priors_r_pre,
+                params.prior_min_samples
+            )
 
             /// combine with reverse read data channel
             ch_denoise1_input_reverse
@@ -259,7 +265,8 @@ workflow DADA2 {
 
             //// get priors for single reads
             PRIORS_S ( 
-                ch_priors_s_pre 
+                ch_priors_s_pre,
+                params.prior_min_samples
             )
             
             /// combine with single read data channel

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -91,6 +91,14 @@
                     "help_text": "Run DADA2 ASV inference in high-sensitivity mode, ie. use pseudo-pooling.",
                     "default": true
                 },
+                "prior_min_samples": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Minimum number of samples an ASV must be present in to be classfied as a 'prior' sequence when using high-sensitivity mode.",
+                    "errorMessage": "Must be an integer >0.",
+                    "help_text": "Minimum number of samples an ASV must be present in to be classfied as a 'prior' sequence when using high-sensitivity mode.",
+                    "default": 2
+                },
                 "dada_band_size": {
                     "type": "integer",
                     "description": "Set BAND_SIZE parameter for dada2::dada denoising function. For explanation, see dada2::setDadaOpt().",


### PR DESCRIPTION
Changes:
- New `--prior_min_samples` parameter controls how many samples a sequence must be found in to be considered a 'prior' sequence in `dada2` high-sensitivity mode (`--high_sensitivity`)
  - `--prior_min_samples 1` allows user to avoid errors when only a single sample for a `read_group`/`primers` combination contains reads during denoising
- Samples whose read count falls to 0 before denoising are now properly handled 
- Samples with input read files that don't contain any reads are removed during `PARSE_INPUTS`
- Resolves bug with R package loading (#112), and packing loading messages are now suppressed from task output